### PR TITLE
Merged config_flow HA changes

### DIFF
--- a/custom_components/monoprice_custom/config_flow.py
+++ b/custom_components/monoprice_custom/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Monoprice 6-Zone Amplifier integration."""
+
 from __future__ import annotations
 
 import logging
@@ -7,8 +8,10 @@ from pymonoprice import get_monoprice
 from serial import SerialException
 import voluptuous as vol
 
-from homeassistant import config_entries, core, exceptions
+from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_PORT
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 
 from .const import (
     CONF_SOURCE_1,
@@ -33,9 +36,11 @@ SOURCES = [
 ]
 
 OPTIONS_FOR_DATA = {vol.Optional(source): str for source in SOURCES}
+
 DATA_SCHEMA = vol.Schema({vol.Required(CONF_PORT): str, **OPTIONS_FOR_DATA})
 
-@core.callback
+
+@callback
 def _sources_from_config(data):
     sources_config = {
         str(idx + 1): data.get(source) for idx, source in enumerate(SOURCES)
@@ -48,7 +53,7 @@ def _sources_from_config(data):
     }
 
 
-async def validate_input(hass: core.HomeAssistant, data):
+async def validate_input(hass: HomeAssistant, data):
     """Validate the user input allows us to connect.
 
     Data has the keys from DATA_SCHEMA with values provided by the user.
@@ -56,17 +61,16 @@ async def validate_input(hass: core.HomeAssistant, data):
     try:
         await hass.async_add_executor_job(get_monoprice, data[CONF_PORT])
     except SerialException as err:
-        _LOGGER.error("Error connecting to Monoprice controller %s", data[CONF_PORT])
+        _LOGGER.error("Error connecting to Monoprice controller")
         raise CannotConnect from err
 
     sources = _sources_from_config(data)
-
 
     # Return info that you want to store in the config entry.
     return {CONF_PORT: data[CONF_PORT], CONF_SOURCES: sources}
 
 
-class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+class MonoPriceConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Monoprice 6-Zone Amplifier."""
 
     VERSION = 1
@@ -90,15 +94,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
 
     @staticmethod
-    @core.callback
+    @callback
     def async_get_options_flow(
-        config_entry: config_entries.ConfigEntry,
+        config_entry: ConfigEntry,
     ) -> MonopriceOptionsFlowHandler:
         """Define the config flow to handle options."""
         return MonopriceOptionsFlowHandler(config_entry)
 
 
-@core.callback
+@callback
 def _key_for_source(index, source, previous_sources):
     if str(index) in previous_sources:
         key = vol.Optional(
@@ -110,14 +114,14 @@ def _key_for_source(index, source, previous_sources):
     return key
 
 
-class MonopriceOptionsFlowHandler(config_entries.OptionsFlow):
+class MonopriceOptionsFlowHandler(OptionsFlow):
     """Handle a Monoprice options flow."""
 
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+    def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize."""
         self.config_entry = config_entry
 
-    @core.callback
+    @callback
     def _previous_sources(self):
         if CONF_SOURCES in self.config_entry.options:
             previous = self.config_entry.options[CONF_SOURCES]
@@ -146,5 +150,5 @@ class MonopriceOptionsFlowHandler(config_entries.OptionsFlow):
         )
 
 
-class CannotConnect(exceptions.HomeAssistantError):
+class CannotConnect(HomeAssistantError):
     """Error to indicate we cannot connect."""

--- a/custom_components/monoprice_custom/media_player.py
+++ b/custom_components/monoprice_custom/media_player.py
@@ -19,7 +19,6 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 import voluptuous as vol
 
 from .const import (
-    CONF_NAME,
     CONF_SOURCES,
     DOMAIN,
     FIRST_RUN,


### PR DESCRIPTION
Sorry to reopen this. I thought the code I had in the original PR did not work. I was testing wrong. It appears it does work. Anyways like I said in the other PR

In https://github.com/thebradleysanders/Monoprice-6-Zone-Audio-Controller/pull/10 this pull request Gabriel mentioned that the config text was broken. I believe this is the missing code that should fix that. As this is part of the rework they did in the official HA integration around the config flow. Also removed the extra "CONF_NAME".