### PR TITLE
Baud zone timeout

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,53 @@
+name: Auto-Release Custom Component
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: # Allows manual triggering from the Actions tab
+
+permissions:
+  contents: write # Required to create tags and releases
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Required to count previous tags for same-day runs
+      
+      - name: Generate version from date (with run counter)
+        id: version
+        run: |
+          git fetch --tags --force
+          CALVER=$(date +'%Y.%m.%d')
+          
+          # Count how many tags already exist today
+          TAG_COUNT=$(git tag -l "v${CALVER}*" | wc -l | xargs)
+          
+          if [ "$TAG_COUNT" -eq 0 ]; then
+            VERSION="$CALVER"
+          else
+            VERSION="${CALVER}.${TAG_COUNT}"
+          fi
+          
+          echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
+          echo "TAG=v$VERSION" >> $GITHUB_OUTPUT
+      
+      - name: Update manifest.json
+        run: |
+          jq ".version = \"${{ steps.version.outputs.VERSION }}\"" custom_components/monoprice_custom/manifest.json > tmp.json && mv tmp.json custom_components/monoprice_custom/manifest.json
+      
+      - name: Zip integration
+        run: |
+          cd custom_components/monoprice_custom
+          zip -r ../../monoprice_6chan.zip .
+      
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.version.outputs.TAG }}" monoprice_6chan.zip \
+            --title "Monoprice 6-Zone Amplifier ${{ steps.version.outputs.TAG }}" \
+            --notes "Automatic release from latest commit: ${{ github.sha }}"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Michael Marvin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Home Assistant Custom Integration: Monoprice 6-Zone Amplifier
-[![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg?style=for-the-badge)](https://github.com/hacs/integration)
 
+[![GitHub Release][releases-shield]][releases]
+[![GitHub Activity][commits-shield]][commits]
+![Install Stats][stats]
+
+![Project Maintenance][maintenance-shield]
+[![Community Forum][forum-shield]][forum]
 
  An Integration for the Monoprice 6-Zone Amplifier, with added sound mode, balance, treble & bass
  This is a modification of the <a href="https://www.home-assistant.io/integrations/monoprice/">existing Monoprice integration</a>.
@@ -31,10 +36,11 @@
 ## Additional Features
 These are features not included in the original Monoprice Integration.
 
- #### Zones
- * 10 - Used to control all zones on the master controller <b>- Entity Disabled, there are known issues, alpha feature.</b>
- * 20 - Used to control all zones on the slave 1 controller <b>- Entity Disabled, there are known issues, alpha feature.</b>
- * 30 - Used to control all zones on the slave 2 controller <b>- Entity Disabled, there are known issues, alpha feature.</b>
+ #### | Zones
+ ---|:---:
+ * 10 | Used to control all zones on the master controller <b>- Entity Disabled, there are known issues, alpha feature.</b>
+ * 20 | Used to control all zones on the slave 1 controller <b>- Entity Disabled, there are known issues, alpha feature.</b>
+ * 30 | Used to control all zones on the slave 2 controller <b>- Entity Disabled, there are known issues, alpha feature.</b>
 
  #### Services
  * <i>monoprice_custom.snapshot</i> 

--- a/blueprints/automation/monoprice/priority_notification.yaml
+++ b/blueprints/automation/monoprice/priority_notification.yaml
@@ -1,0 +1,57 @@
+blueprint:
+  name: Monoprice Zone Interrupt / Priority Notification
+  description: Snapshots specified zones, plays a notification, and restores previous volume, power, and source states.
+  domain: automation
+  input:
+    target_zones:
+      name: Target Monoprice Zones
+      selector:
+        target:
+          entity:
+            filter:
+              - domain: media_player
+                integration: monoprice
+    trigger_event:
+      name: Trigger Sensor (e.g., Doorbell)
+      selector:
+        entity:
+          filter:
+            - domain: binary_sensor
+    announcement_message:
+      name: TTS Message
+      default: "Attention: Someone is at the front door."
+      selector:
+        text:
+
+trigger:
+  - platform: state
+    entity_id: !input trigger_event
+    to: "on"
+
+action:
+  # 1. Save state
+  - action: monoprice.snapshot
+    target: !input target_zones
+
+  # 2. Prep zones for announcement
+  - action: media_player.turn_on
+    target: !input target_zones
+  - action: media_player.volume_set
+    target: !input target_zones
+    data:
+      volume_level: 0.50
+
+  # 3. Play notification (using your preferred TTS service)
+  - action: tts.speak
+    target:
+      entity_id: tts.google_en_com
+    data:
+      media_player_entity_id: !input target_zones
+      message: !input announcement_message
+
+  - delay:
+      seconds: 5
+
+  # 4. Restore original state
+  - action: monoprice.restore
+    target: !input target_zones

--- a/blueprints/automation/monoprice/zone_auto_off.yaml
+++ b/blueprints/automation/monoprice/zone_auto_off.yaml
@@ -1,0 +1,40 @@
+blueprint:
+  name: Monoprice Zone Auto-Power Off
+  description: Automatically turns off a Monoprice zone when the room is vacant or the source goes idle.
+  domain: automation
+  input:
+    monoprice_zone:
+      name: Monoprice Zone
+      selector:
+        entity:
+          filter:
+            - domain: media_player
+              integration: monoprice
+    occupancy_sensor:
+      name: Presence/Motion Sensor (Optional)
+      default: []
+      selector:
+        entity:
+          filter:
+            - domain: binary_sensor
+              device_class: occupancy
+    no_motion_wait:
+      name: Delay before turning off
+      default: 15
+      selector:
+        number:
+          min: 1
+          max: 120
+          unit_of_measurement: minutes
+
+trigger:
+  - platform: state
+    entity_id: !input occupancy_sensor
+    to: "off"
+    for:
+      minutes: !input no_motion_wait
+
+action:
+  - action: media_player.turn_off
+    target:
+      entity_id: !input monoprice_zone

--- a/blueprints/script/monoprice/party_mode_sync.yaml
+++ b/blueprints/script/monoprice/party_mode_sync.yaml
@@ -1,0 +1,29 @@
+alias: "Audio: Party Mode All Zones"
+sequence:
+  # Turn on all background zones
+  - action: media_player.turn_on
+    target:
+      entity_id:
+        - media_player.patio_zone
+        - media_player.kitchen_zone
+        - media_player.living_room_zone
+  # Align all to Source 1 (Main Feed)
+  - action: media_player.select_source
+    target:
+      entity_id:
+        - media_player.patio_zone
+        - media_player.kitchen_zone
+        - media_player.living_room_zone
+    data:
+      source: "Source 1"
+  # Set ambient volume levels per room
+  - action: media_player.volume_set
+    target:
+      entity_id: media_player.kitchen_zone
+    data:
+      volume_level: 0.35
+  - action: media_player.volume_set
+    target:
+      entity_id: media_player.patio_zone
+    data:
+      volume_level: 0.50

--- a/custom_components/monoprice_custom/__init__.py
+++ b/custom_components/monoprice_custom/__init__.py
@@ -36,8 +36,8 @@ class MonopriceData:
     coordinator: MonopriceCoordinator
     first_run: bool
 
-# Platinum strict typing for the config entry
-type MonopriceConfigEntry = ConfigEntry[MonopriceData]
+# Backwards-compatible typing
+MonopriceConfigEntry = ConfigEntry
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: MonopriceConfigEntry) -> bool:

--- a/custom_components/monoprice_custom/__init__.py
+++ b/custom_components/monoprice_custom/__init__.py
@@ -15,6 +15,7 @@ from .const import (
     CONF_NOT_FIRST_RUN,
     DOMAIN,
     FIRST_RUN,
+    PLATFORMS
 )
 from .coordinator import MonopriceCoordinator
 

--- a/custom_components/monoprice_custom/__init__.py
+++ b/custom_components/monoprice_custom/__init__.py
@@ -1,5 +1,6 @@
 """The Monoprice 6-Zone Amplifier integration."""
 import logging
+from dataclasses import dataclass
 
 from pymonoprice import get_monoprice
 from serial import SerialException
@@ -9,28 +10,52 @@ from homeassistant.const import CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
+# MONOPRICE_OBJECT and UNDO_UPDATE_LISTENER were removed from .const
 from .const import (
     CONF_NOT_FIRST_RUN,
     DOMAIN,
     FIRST_RUN,
-    MONOPRICE_OBJECT,
-    UNDO_UPDATE_LISTENER,
 )
+from .coordinator import MonopriceCoordinator
 
-PLATFORMS = [Platform.MEDIA_PLAYER, Platform.SENSOR, Platform.NUMBER]
+# Added SWITCH and REMOTE to support the new features
+PLATFORMS = [
+    Platform.MEDIA_PLAYER, 
+    Platform.SENSOR, 
+    Platform.NUMBER,
+    Platform.SWITCH,
+    Platform.REMOTE
+]
 
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+@dataclass
+class MonopriceData:
+    """Class to hold runtime data for the Monoprice integration."""
+    coordinator: MonopriceCoordinator
+    first_run: bool
+
+# Platinum strict typing for the config entry
+type MonopriceConfigEntry = ConfigEntry[MonopriceData]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: MonopriceConfigEntry) -> bool:
     """Set up Monoprice 6-Zone Amplifier from a config entry."""
     port = entry.data[CONF_PORT]
 
     try:
+        # Spin up the synchronous serial connection in the executor
         monoprice = await hass.async_add_executor_job(get_monoprice, port)
     except SerialException as err:
         _LOGGER.error("Error connecting to Monoprice controller at %s", port)
         raise ConfigEntryNotReady from err
+
+    # Initialize the coordinator
+    coordinator = MonopriceCoordinator(hass, monoprice)
+    
+    # Fetch initial state before loading platforms so entities don't boot as "Unavailable"
+    await coordinator.async_config_entry_first_refresh()
 
     # double negative to handle absence of value
     first_run = not bool(entry.data.get(CONF_NOT_FIRST_RUN))
@@ -40,29 +65,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry, data={**entry.data, CONF_NOT_FIRST_RUN: True}
         )
 
-    undo_listener = entry.add_update_listener(_update_listener)
+    # Modern listener registration - HA automatically cleans this up on unload
+    entry.async_on_unload(entry.add_update_listener(_update_listener))
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = {
-        MONOPRICE_OBJECT: monoprice,
-        UNDO_UPDATE_LISTENER: undo_listener,
-        FIRST_RUN: first_run,
-    }
+    # Platinum standard: Use entry.runtime_data instead of hass.data
+    entry.runtime_data = MonopriceData(
+        coordinator=coordinator,
+        first_run=first_run
+    )
 
+    # Load all defined platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: MonopriceConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload_ok:
-        hass.data[DOMAIN][entry.entry_id][UNDO_UPDATE_LISTENER]()
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    # The undo_listener and hass.data.pop() logic is no longer needed.
+    # async_on_unload handles the listener, and runtime_data is destroyed automatically.
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
-async def _update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def _update_listener(hass: HomeAssistant, entry: MonopriceConfigEntry) -> None:
     """Handle options update."""
     await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/monoprice_custom/__init__.py
+++ b/custom_components/monoprice_custom/__init__.py
@@ -15,7 +15,7 @@ from .const import (
     CONF_NOT_FIRST_RUN,
     DOMAIN,
     FIRST_RUN,
-    PLATFORMS
+    PLATFORMS,
 )
 from .coordinator import MonopriceCoordinator
 

--- a/custom_components/monoprice_custom/config_flow.py
+++ b/custom_components/monoprice_custom/config_flow.py
@@ -2,13 +2,16 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from pymonoprice import get_monoprice
 from serial import SerialException
+import serial.tools.list_ports
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
 from homeassistant.const import CONF_PORT
+from homeassistant.helpers import selector
 
 from .const import (
     CONF_SOURCE_1,
@@ -33,10 +36,10 @@ SOURCES = [
 ]
 
 OPTIONS_FOR_DATA = {vol.Optional(source): str for source in SOURCES}
-DATA_SCHEMA = vol.Schema({vol.Required(CONF_PORT): str, **OPTIONS_FOR_DATA})
+
 
 @core.callback
-def _sources_from_config(data):
+def _sources_from_config(data: dict[str, Any]) -> dict[str, str]:
     sources_config = {
         str(idx + 1): data.get(source) for idx, source in enumerate(SOURCES)
     }
@@ -48,19 +51,19 @@ def _sources_from_config(data):
     }
 
 
-async def validate_input(hass: core.HomeAssistant, data):
+async def validate_input(hass: core.HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect.
 
     Data has the keys from DATA_SCHEMA with values provided by the user.
     """
     try:
+        # Wrapped in executor to maintain async standards
         await hass.async_add_executor_job(get_monoprice, data[CONF_PORT])
     except SerialException as err:
         _LOGGER.error("Error connecting to Monoprice controller %s", data[CONF_PORT])
         raise CannotConnect from err
 
     sources = _sources_from_config(data)
-
 
     # Return info that you want to store in the config entry.
     return {CONF_PORT: data[CONF_PORT], CONF_SOURCES: sources}
@@ -71,13 +74,15 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
         """Handle the initial step."""
         errors = {}
+
         if user_input is not None:
             try:
                 info = await validate_input(self.hass, user_input)
-
                 return self.async_create_entry(title=user_input[CONF_PORT], data=info)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
@@ -85,8 +90,34 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
 
+        # Dynamically scan ports in executor job (Platinum requirement)
+        ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
+        
+        # Build the dropdown options
+        port_options = [
+            selector.SelectOptionDict(
+                value=port.device,
+                label=f"{port.device} - {port.description}" if port.description and port.description != "n/a" else port.device,
+            )
+            for port in ports
+        ]
+
+        # Build schema using the dynamic dropdown alongside the sources
+        data_schema = vol.Schema(
+            {
+                vol.Required(CONF_PORT): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=port_options,
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                        custom_value=True,
+                    )
+                ),
+                **OPTIONS_FOR_DATA,
+            }
+        )
+
         return self.async_show_form(
-            step_id="user", data_schema=DATA_SCHEMA, errors=errors
+            step_id="user", data_schema=data_schema, errors=errors
         )
 
     @staticmethod
@@ -99,7 +130,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 
 @core.callback
-def _key_for_source(index, source, previous_sources):
+def _key_for_source(index: int, source: str, previous_sources: dict[str, Any]) -> vol.Optional:
     if str(index) in previous_sources:
         key = vol.Optional(
             source, description={"suggested_value": previous_sources[str(index)]}
@@ -118,7 +149,7 @@ class MonopriceOptionsFlowHandler(config_entries.OptionsFlow):
         self.config_entry = config_entry
 
     @core.callback
-    def _previous_sources(self):
+    def _previous_sources(self) -> dict[str, Any]:
         if CONF_SOURCES in self.config_entry.options:
             previous = self.config_entry.options[CONF_SOURCES]
         else:
@@ -126,7 +157,9 @@ class MonopriceOptionsFlowHandler(config_entries.OptionsFlow):
 
         return previous
 
-    async def async_step_init(self, user_input=None):
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
         """Manage the options."""
         if user_input is not None:
             return self.async_create_entry(

--- a/custom_components/monoprice_custom/config_flow.py
+++ b/custom_components/monoprice_custom/config_flow.py
@@ -2,10 +2,13 @@
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 from pymonoprice import get_monoprice
+import serial
 from serial import SerialException
+import serial.tools.list_ports
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
@@ -37,6 +40,30 @@ SOURCES = [
 OPTIONS_FOR_DATA = {vol.Optional(source): str for source in SOURCES}
 
 
+def _resolve_path(path: str) -> str:
+    """Resolve symlinks like /dev/serial/by-id/... to /dev/ttyUSBx."""
+    try:
+        return os.path.realpath(path)
+    except Exception:
+        return path
+
+
+def _find_dev_paths(obj: Any) -> set[str]:
+    """Recursively search a data structure for any device paths starting with /dev/."""
+    found = set()
+    if isinstance(obj, dict):
+        for val in obj.values():
+            found.update(_find_dev_paths(val))
+    elif isinstance(obj, (list, tuple, set)):
+        for item in obj:
+            found.update(_find_dev_paths(item))
+    elif isinstance(obj, str):
+        if obj.startswith("/dev/"):
+            found.add(obj)
+            found.add(_resolve_path(obj))
+    return found
+
+
 @core.callback
 def _sources_from_config(data: dict[str, Any]) -> dict[str, str]:
     sources_config = {
@@ -53,15 +80,12 @@ def _sources_from_config(data: dict[str, Any]) -> dict[str, str]:
 async def validate_input(hass: core.HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
     """Validate the user input allows us to connect."""
     try:
-        # Wrapped in executor to maintain async standards
         await hass.async_add_executor_job(get_monoprice, data[CONF_PORT])
     except SerialException as err:
         _LOGGER.error("Error connecting to Monoprice controller %s", data[CONF_PORT])
         raise CannotConnect from err
 
     sources = _sources_from_config(data)
-
-    # Return info that you want to store in the config entry.
     return {CONF_PORT: data[CONF_PORT], CONF_SOURCES: sources}
 
 
@@ -80,14 +104,82 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return self.async_create_entry(title=user_input[CONF_PORT], data=info)
             except CannotConnect:
                 errors["base"] = "cannot_connect"
-            except Exception:  # pylint: disable=broad-except
+            except Exception:  
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
 
-        # Build schema using the native UI Selector alongside source renaming options
+        # 1. Map all active HA integration entries to device paths they consume
+        ha_configured_ports: dict[str, str] = {}
+        for entry in self.hass.config_entries.async_entries():
+            dev_paths = _find_dev_paths(entry.data) | _find_dev_paths(entry.options)
+            for path in dev_paths:
+                # Store domain (e.g. 'zwave_js', 'zha', 'elkm1')
+                ha_configured_ports[path] = entry.domain
+
+        # 2. Smart Hardware Probe
+        def _get_port_status(port):
+            device_path = port.device
+            resolved_path = _resolve_path(device_path)
+            
+            status_label = "(Available)"
+            amp = None
+
+            # If HA already claimed this port for another integration, skip probing completely
+            if device_path in ha_configured_ports or resolved_path in ha_configured_ports:
+                using_domain = ha_configured_ports.get(device_path) or ha_configured_ports.get(resolved_path)
+                status_label = f"(In Use by {using_domain})"
+            else:
+                # Safe to probe: test if the port responds to Monoprice commands
+                try:
+                    amp = get_monoprice(device_path)
+                    
+                    # Temporarily drop timeout to 0.5s so non-matching ports don't delay the UI
+                    if hasattr(amp, "_port"):
+                        amp._port.timeout = 0.5
+                        amp._port.write(b"\r\n")
+                    
+                    # Query Zone 11 to see if amplifier responds
+                    zone_status = amp.zone_status(11)
+                    if zone_status:
+                        status_label = "(Monoprice Amp Detected) 🎯"
+                        
+                except Exception as err:
+                    if "timed out" in str(err) or "received bytes" in str(err):
+                        status_label = "(Available)"
+                    else:
+                        # PermissionError, OS lock, or busy
+                        status_label = "(In Use by OS)"
+                finally:
+                    # Failsafe: Always close the serial port immediately
+                    try:
+                        if amp and hasattr(amp, "_port") and amp._port.is_open:
+                            amp._port.close()
+                    except Exception:
+                        pass
+
+            label = f"{device_path} - {port.description}" if port.description and port.description != "n/a" else device_path
+            
+            return {
+                "value": device_path,
+                "label": f"{label} {status_label}",
+            }
+
+        # 3. Offload scanning and probing to the executor
+        ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
+        port_options = await self.hass.async_add_executor_job(
+            lambda: [_get_port_status(p) for p in ports]
+        )
+
+        # Build schema using the dynamic dropdown
         data_schema = vol.Schema(
             {
-                vol.Required(CONF_PORT): selector.SerialPortSelector(),
+                vol.Required(CONF_PORT): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=port_options,
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                        custom_value=True,
+                    )
+                ),
                 **OPTIONS_FOR_DATA,
             }
         )
@@ -113,7 +205,6 @@ def _key_for_source(index: int, source: str, previous_sources: dict[str, Any]) -
         )
     else:
         key = vol.Optional(source)
-
     return key
 
 
@@ -126,7 +217,6 @@ class MonopriceOptionsFlowHandler(config_entries.OptionsFlow):
             previous = self.config_entry.options[CONF_SOURCES]
         else:
             previous = self.config_entry.data[CONF_SOURCES]
-
         return previous
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None):
@@ -137,7 +227,6 @@ class MonopriceOptionsFlowHandler(config_entries.OptionsFlow):
             )
 
         previous_sources = self._previous_sources()
-
         options = {
             _key_for_source(idx + 1, source, previous_sources): str
             for idx, source in enumerate(SOURCES)

--- a/custom_components/monoprice_custom/config_flow.py
+++ b/custom_components/monoprice_custom/config_flow.py
@@ -116,46 +116,48 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 # Store domain (e.g. 'zwave_js', 'zha', 'elkm1')
                 ha_configured_ports[path] = entry.domain
 
-        # 2. Smart Hardware Probe
+        # 2. Smart Hardware Probe (Direct RS232 Protocol Check)
         def _get_port_status(port):
             device_path = port.device
             resolved_path = _resolve_path(device_path)
             
             status_label = "(Available)"
-            amp = None
 
-            # If HA already claimed this port for another integration, skip probing completely
+            # Skip hardware probe if Home Assistant already claimed this port
             if device_path in ha_configured_ports or resolved_path in ha_configured_ports:
                 using_domain = ha_configured_ports.get(device_path) or ha_configured_ports.get(resolved_path)
                 status_label = f"(In Use by {using_domain})"
             else:
-                # Safe to probe: test if the port responds to Monoprice commands
+                # Raw RS232 Probe: Fast, direct, and buffer-safe
                 try:
-                    amp = get_monoprice(device_path)
-                    
-                    # Temporarily drop timeout to 0.5s so non-matching ports don't delay the UI
-                    if hasattr(amp, "_port"):
-                        amp._port.timeout = 0.5
-                        amp._port.write(b"\r\n")
-                    
-                    # Query Zone 11 to see if amplifier responds
-                    zone_status = amp.zone_status(11)
-                    if zone_status:
-                        status_label = "(Monoprice Amp Detected) 🎯"
-                        
-                except Exception as err:
-                    if "timed out" in str(err) or "received bytes" in str(err):
-                        status_label = "(Available)"
-                    else:
-                        # PermissionError, OS lock, or busy
-                        status_label = "(In Use by OS)"
-                finally:
-                    # Failsafe: Always close the serial port immediately
-                    try:
-                        if amp and hasattr(amp, "_port") and amp._port.is_open:
-                            amp._port.close()
-                    except Exception:
-                        pass
+                    with serial.Serial(device_path, 9600, timeout=1.0) as ser:
+                        # Flush any stale data out of the hardware buffers
+                        ser.reset_input_buffer()
+                        ser.reset_output_buffer()
+
+                        # Send wake-up byte and clear any resulting echo
+                        ser.write(b"\r\n")
+                        ser.flush()
+                        ser.reset_input_buffer()
+
+                        # Send Zone 11 inquiry command (?11\r) per Monoprice RS232 manual
+                        ser.write(b"?11\r")
+                        ser.flush()
+
+                        # Read up to 30 bytes from the port
+                        response = ser.read(30)
+
+                        # Monoprice amplifiers always reply with ">11..." or ">10..."
+                        if b">11" in response or b">10" in response or b">" in response:
+                            status_label = "(Monoprice Amp Detected) 🎯"
+                        else:
+                            status_label = "(Available)"
+
+                except (SerialException, PermissionError, OSError):
+                    # Port is locked by another OS process or container
+                    status_label = "(In Use by OS)"
+                except Exception:
+                    status_label = "(Available)"
 
             label = f"{device_path} - {port.description}" if port.description and port.description != "n/a" else device_path
             

--- a/custom_components/monoprice_custom/config_flow.py
+++ b/custom_components/monoprice_custom/config_flow.py
@@ -126,7 +126,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         config_entry: config_entries.ConfigEntry,
     ) -> MonopriceOptionsFlowHandler:
         """Define the config flow to handle options."""
-        return MonopriceOptionsFlowHandler(config_entry)
+        return MonopriceOptionsFlowHandler()
 
 
 @core.callback
@@ -143,10 +143,6 @@ def _key_for_source(index: int, source: str, previous_sources: dict[str, Any]) -
 
 class MonopriceOptionsFlowHandler(config_entries.OptionsFlow):
     """Handle a Monoprice options flow."""
-
-    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
-        """Initialize."""
-        self.config_entry = config_entry
 
     @core.callback
     def _previous_sources(self) -> dict[str, Any]:

--- a/custom_components/monoprice_custom/config_flow.py
+++ b/custom_components/monoprice_custom/config_flow.py
@@ -76,7 +76,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> config_entries.ConfigFlowResult:
+    ):
         """Handle the initial step."""
         errors = {}
 
@@ -95,10 +95,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         
         # Build the dropdown options
         port_options = [
-            selector.SelectOptionDict(
-                value=port.device,
-                label=f"{port.device} - {port.description}" if port.description and port.description != "n/a" else port.device,
-            )
+            {
+                "value": port.device,
+                "label": f"{port.device} - {port.description}" if port.description and port.description != "n/a" else port.device,
+            }
             for port in ports
         ]
 
@@ -159,7 +159,7 @@ class MonopriceOptionsFlowHandler(config_entries.OptionsFlow):
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
-    ) -> config_entries.ConfigFlowResult:
+    ):
         """Manage the options."""
         if user_input is not None:
             return self.async_create_entry(

--- a/custom_components/monoprice_custom/config_flow.py
+++ b/custom_components/monoprice_custom/config_flow.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any
 
 from pymonoprice import get_monoprice
+import serial
 from serial import SerialException
 import serial.tools.list_ports
 import voluptuous as vol
@@ -52,10 +53,7 @@ def _sources_from_config(data: dict[str, Any]) -> dict[str, str]:
 
 
 async def validate_input(hass: core.HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
-    """Validate the user input allows us to connect.
-
-    Data has the keys from DATA_SCHEMA with values provided by the user.
-    """
+    """Validate the user input allows us to connect."""
     try:
         # Wrapped in executor to maintain async standards
         await hass.async_add_executor_job(get_monoprice, data[CONF_PORT])
@@ -74,9 +72,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ):
+    async def async_step_user(self, user_input: dict[str, Any] | None = None):
         """Handle the initial step."""
         errors = {}
 
@@ -90,19 +86,45 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
 
-        # Dynamically scan ports in executor job (Platinum requirement)
-        ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
-        
-        # Build the dropdown options
-        port_options = [
-            {
-                "value": port.device,
-                "label": f"{port.device} - {port.description}" if port.description and port.description != "n/a" else port.device,
-            }
-            for port in ports
-        ]
+        # 1. Get a list of ports currently configured across all HA integration entries
+        ha_configured_ports = {
+            entry.data.get(CONF_PORT)
+            for entry in self.hass.config_entries.async_entries()
+            if CONF_PORT in entry.data
+        }
 
-        # Build schema using the dynamic dropdown alongside the sources
+        # 2. Hardware/Registry Probe logic
+        def _get_port_status(port):
+            device_path = port.device
+            is_in_use = False
+
+            # Check HA integration registry first
+            if device_path in ha_configured_ports:
+                is_in_use = True
+            else:
+                # Hardware Probe: Try to open port briefly
+                try:
+                    test_conn = serial.Serial(device_path)
+                    test_conn.close()
+                except (SerialException, PermissionError, OSError):
+                    is_in_use = True
+
+            label = f"{device_path} - {port.description}" if port.description and port.description != "n/a" else device_path
+            if is_in_use:
+                label = f"{label} (In Use)"
+
+            return {
+                "value": device_path,
+                "label": label,
+            }
+
+        # 3. Offload serial port scanning & hardware probing to the executor
+        ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
+        port_options = await self.hass.async_add_executor_job(
+            lambda: [_get_port_status(p) for p in ports]
+        )
+
+        # Build schema using dynamic dropdown alongside source renaming options
         data_schema = vol.Schema(
             {
                 vol.Required(CONF_PORT): selector.SelectSelector(
@@ -153,9 +175,7 @@ class MonopriceOptionsFlowHandler(config_entries.OptionsFlow):
 
         return previous
 
-    async def async_step_init(
-        self, user_input: dict[str, Any] | None = None
-    ):
+    async def async_step_init(self, user_input: dict[str, Any] | None = None):
         """Manage the options."""
         if user_input is not None:
             return self.async_create_entry(

--- a/custom_components/monoprice_custom/config_flow.py
+++ b/custom_components/monoprice_custom/config_flow.py
@@ -5,9 +5,7 @@ import logging
 from typing import Any
 
 from pymonoprice import get_monoprice
-import serial
 from serial import SerialException
-import serial.tools.list_ports
 import voluptuous as vol
 
 from homeassistant import config_entries, core, exceptions
@@ -86,54 +84,10 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
 
-        # 1. Get a list of ports currently configured across all HA integration entries
-        ha_configured_ports = {
-            entry.data.get(CONF_PORT)
-            for entry in self.hass.config_entries.async_entries()
-            if CONF_PORT in entry.data
-        }
-
-        # 2. Hardware/Registry Probe logic
-        def _get_port_status(port):
-            device_path = port.device
-            is_in_use = False
-
-            # Check HA integration registry first
-            if device_path in ha_configured_ports:
-                is_in_use = True
-            else:
-                # Hardware Probe: Try to open port briefly
-                try:
-                    test_conn = serial.Serial(device_path)
-                    test_conn.close()
-                except (SerialException, PermissionError, OSError):
-                    is_in_use = True
-
-            label = f"{device_path} - {port.description}" if port.description and port.description != "n/a" else device_path
-            if is_in_use:
-                label = f"{label} (In Use)"
-
-            return {
-                "value": device_path,
-                "label": label,
-            }
-
-        # 3. Offload serial port scanning & hardware probing to the executor
-        ports = await self.hass.async_add_executor_job(serial.tools.list_ports.comports)
-        port_options = await self.hass.async_add_executor_job(
-            lambda: [_get_port_status(p) for p in ports]
-        )
-
-        # Build schema using dynamic dropdown alongside source renaming options
+        # Build schema using the native UI Selector alongside source renaming options
         data_schema = vol.Schema(
             {
-                vol.Required(CONF_PORT): selector.SelectSelector(
-                    selector.SelectSelectorConfig(
-                        options=port_options,
-                        mode=selector.SelectSelectorMode.DROPDOWN,
-                        custom_value=True,
-                    )
-                ),
+                vol.Required(CONF_PORT): selector.SerialPortSelector(),
                 **OPTIONS_FOR_DATA,
             }
         )

--- a/custom_components/monoprice_custom/const.py
+++ b/custom_components/monoprice_custom/const.py
@@ -4,6 +4,7 @@ from homeassistant.const import Platform
 DOMAIN = "monoprice"
 CONF_PORT = "port"
 
+# Platinum Platform list (Enables the new EQ and RS232 features)
 PLATFORMS = [
     Platform.MEDIA_PLAYER,
     Platform.REMOTE,
@@ -13,8 +14,8 @@ PLATFORMS = [
 ]
 DOMAIN = "monoprice"
 
+# Configuration UI and Source Keys
 CONF_SOURCES = "sources"
-
 CONF_SOURCE_1 = "source_1"
 CONF_SOURCE_2 = "source_2"
 CONF_SOURCE_3 = "source_3"
@@ -22,6 +23,13 @@ CONF_SOURCE_4 = "source_4"
 CONF_SOURCE_5 = "source_5"
 CONF_SOURCE_6 = "source_6"
 
+# Compatibility strings for media_player.py imports
+CONF_NAME = "name"
+MONOPRICE_OBJECT = "monoprice"
+UNDO_UPDATE_LISTENER = "undo_update_listener"
+
+# Integration lifecycle tracking
+FIRST_RUN = "first_run"
 CONF_NOT_FIRST_RUN = "not_first_run"
 
 SERVICE_SNAPSHOT = "snapshot"
@@ -30,7 +38,6 @@ SERVICE_SET_BALANCE = "set_balance"
 SERVICE_SET_BASS = "set_bass"
 SERVICE_SET_TREBLE = "set_treble"
 
-FIRST_RUN = "first_run"
 
 ATTR_BALANCE = "level"
 ATTR_BASS = "level"

--- a/custom_components/monoprice_custom/const.py
+++ b/custom_components/monoprice_custom/const.py
@@ -4,13 +4,14 @@ from homeassistant.const import Platform
 DOMAIN = "monoprice"
 CONF_PORT = "port"
 
-# Platinum Platform list (Enables the new EQ and RS232 features)
+# Platinum Platform list
 PLATFORMS = [
     Platform.MEDIA_PLAYER,
-    Platform.REMOTE,
-    Platform.NUMBER,
     Platform.SWITCH,
     Platform.SENSOR,
+    Platform.NUMBER,
+    Platform.TEXT,
+    Platform.REMOTE,
 ]
 DOMAIN = "monoprice"
 
@@ -22,6 +23,11 @@ CONF_SOURCE_3 = "source_3"
 CONF_SOURCE_4 = "source_4"
 CONF_SOURCE_5 = "source_5"
 CONF_SOURCE_6 = "source_6"
+
+# Service Attributes
+ATTR_BALANCE = "balance"
+ATTR_BASS = "bass"
+ATTR_TREBLE = "treble"
 
 # Compatibility strings for media_player.py imports
 CONF_NAME = "name"

--- a/custom_components/monoprice_custom/const.py
+++ b/custom_components/monoprice_custom/const.py
@@ -31,8 +31,6 @@ SERVICE_SET_BASS = "set_bass"
 SERVICE_SET_TREBLE = "set_treble"
 
 FIRST_RUN = "first_run"
-MONOPRICE_OBJECT = "monoprice_object"
-UNDO_UPDATE_LISTENER = "update_update_listener"
 
 ATTR_BALANCE = "level"
 ATTR_BASS = "level"

--- a/custom_components/monoprice_custom/const.py
+++ b/custom_components/monoprice_custom/const.py
@@ -1,5 +1,16 @@
 """Constants for the Monoprice 6-Zone Amplifier Media Player component."""
+from homeassistant.const import Platform
 
+DOMAIN = "monoprice"
+CONF_PORT = "port"
+
+PLATFORMS = [
+    Platform.MEDIA_PLAYER,
+    Platform.REMOTE,
+    Platform.NUMBER,
+    Platform.SWITCH,
+    Platform.SENSOR,
+]
 DOMAIN = "monoprice"
 
 CONF_SOURCES = "sources"

--- a/custom_components/monoprice_custom/coordinator.py
+++ b/custom_components/monoprice_custom/coordinator.py
@@ -1,8 +1,93 @@
 from datetime import timedelta
 import logging
+import time
+
+from serial import SerialException, SerialTimeoutException
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 _LOGGER = logging.getLogger(__name__)
+
+TARGET_BAUD = 38400
+
+def optimize_serial_baudrate(amp, target_baud: int = TARGET_BAUD) -> int:
+    """Negotiate optimal baud rate with the Monoprice amplifier."""
+    if not hasattr(amp, "_port") or not amp._port:
+        return 9600
+
+    ser = amp._port
+
+    # --- Step 1: Test if amp is ALREADY at target_baud ---
+    ser.baudrate = target_baud
+    ser.reset_input_buffer()
+    ser.reset_output_buffer()
+    try:
+        ser.write(b"?11\r")
+        ser.flush()
+        time.sleep(0.05)
+        response = ser.read(30)
+        if b">" in response:
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                _LOGGER.debug("Monoprice amplifier communicating at %d baud", target_baud)
+            return target_baud
+    except Exception:
+        pass
+
+    # --- Step 2: Fall back to 9600 baud (Power-On Default) ---
+    ser.baudrate = 9600
+    ser.reset_input_buffer()
+    ser.reset_output_buffer()
+    try:
+        ser.write(b"\r\n?11\r")
+        ser.flush()
+        time.sleep(0.05)
+        response = ser.read(30)
+        if b">" not in response:
+            _LOGGER.warning("Monoprice amplifier did not respond at 9600 baud.")
+            return 9600
+    except Exception as err:
+        _LOGGER.warning("Error checking 9600 baud baseline: %s", err)
+        return 9600
+
+    _LOGGER.info("Connected at 9600 baud. Upgrading speed to %d baud...", target_baud)
+
+    # --- Step 3: Send speed upgrade command ($<BAUD'CR') ---
+    try:
+        cmd = f"$<{target_baud}\r".encode("ascii")
+        ser.write(cmd)
+        ser.flush()
+        time.sleep(0.1)
+
+        # --- Step 4: Switch local serial port to target_baud ---
+        ser.baudrate = target_baud
+        ser.reset_input_buffer()
+        ser.reset_output_buffer()
+
+        # --- Step 5: Verify high-speed communication ---
+        ser.write(b"?11\r")
+        ser.flush()
+        time.sleep(0.05)
+        response_high = ser.read(30)
+
+        if b">" in response_high:
+            _LOGGER.info("Successfully upgraded Monoprice serial link to %d baud!", target_baud)
+            return target_baud
+    except Exception as err:
+        _LOGGER.warning("Failed during baud rate upgrade attempt: %s", err)
+
+    # --- Step 6: Failsafe Revert ---
+    _LOGGER.warning("Reverting local serial port and amplifier to 9600 baud.")
+    try:
+        ser.write(b"$<9600\r")
+        ser.flush()
+        time.sleep(0.1)
+    except Exception:
+        pass
+
+    ser.baudrate = 9600
+    ser.reset_input_buffer()
+    ser.reset_output_buffer()
+    return 9600
+
 
 class MonopriceCoordinator(DataUpdateCoordinator):
     """Class to manage fetching Monoprice data asynchronously."""
@@ -10,6 +95,11 @@ class MonopriceCoordinator(DataUpdateCoordinator):
     def __init__(self, hass, api):
         """Initialize."""
         self.api = api
+        
+        # NEW: State trackers for recovery and speed optimization
+        self.active_units: list[int] = []
+        self._baud_optimized: bool = False
+        
         super().__init__(
             hass,
             _LOGGER,
@@ -20,19 +110,51 @@ class MonopriceCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         """Fetch data from the amp via executor job."""
         try:
-            # Wake-up ping
+            # --- NEW: 1. Ensure Baud Rate is Optimized ---
+            if not self._baud_optimized:
+                await self.hass.async_add_executor_job(
+                    optimize_serial_baudrate, self.api, TARGET_BAUD
+                )
+                self._baud_optimized = True
+
+            # --- NEW: 2. One-Time Active Unit Discovery ---
+            if not self.active_units:
+                active = [1]
+                try:
+                    if _LOGGER.isEnabledFor(logging.DEBUG):
+                        _LOGGER.debug("Probing for expansion Unit 2 (Zone 21)...")
+                    status_u2 = await self.hass.async_add_executor_job(self.api.zone_status, 21)
+                    if status_u2:
+                        active.append(2)
+                        
+                        if _LOGGER.isEnabledFor(logging.DEBUG):
+                            _LOGGER.debug("Probing for expansion Unit 3 (Zone 31)...")
+                        status_u3 = await self.hass.async_add_executor_job(self.api.zone_status, 31)
+                        if status_u3:
+                            active.append(3)
+                except Exception:
+                    pass
+                self.active_units = active
+                
+                if _LOGGER.isEnabledFor(logging.DEBUG):
+                    _LOGGER.debug("Active units locked to: %s", self.active_units)
+
+            # --- ORIGINAL: Wake-up ping ---
             try:
-                _LOGGER.debug("Sending wake-up ping to amplifier.")
+                if _LOGGER.isEnabledFor(logging.DEBUG):
+                    _LOGGER.debug("Sending wake-up ping to amplifier.")
                 await self.hass.async_add_executor_job(self.api.serial.write, b"\r\n")
             except Exception as e:
-                _LOGGER.debug("Wake-up ping failed (expected if locked): %s", e)
+                if _LOGGER.isEnabledFor(logging.DEBUG):
+                    _LOGGER.debug("Wake-up ping failed (expected if locked): %s", e)
 
             zones = {}
-            for i in range(1, 4):
+            
+            # --- MODIFIED: Loop only over discovered active units ---
+            for unit in self.active_units:
                 for j in range(1, 7):
-                    zone_id = (i * 10) + j
+                    zone_id = (unit * 10) + j
                     
-                    # Performance optimization: Only build log strings if debug is on
                     if _LOGGER.isEnabledFor(logging.DEBUG):
                         _LOGGER.debug("Requesting status for Zone %s", zone_id)
                         
@@ -52,15 +174,34 @@ class MonopriceCoordinator(DataUpdateCoordinator):
                     except Exception as loop_err:
                         if "Connection timed out" in str(loop_err):
                             if _LOGGER.isEnabledFor(logging.DEBUG):
-                                _LOGGER.debug("Timeout requesting Zone %s (Unit %s may not exist)", zone_id, i)
-                            if i > 1:
+                                _LOGGER.debug("Timeout requesting Zone %s (Unit %s may not exist)", zone_id, unit)
+                            if unit > 1:
                                 pass # Ignore timeouts for secondary units
                             else:
                                 raise loop_err
                         else:
                             raise loop_err
+
+                # --- NEW: Poll Master Zone for unit (10, 20, 30) ---
+                try:
+                    master_id = unit * 10
+                    master_status = await self.hass.async_add_executor_job(
+                        self.api.zone_status, master_id
+                    )
+                    if master_status:
+                        zones[master_id] = master_status
+                except Exception:
+                    pass
                             
             return zones
             
+        except (SerialException, SerialTimeoutException) as err:
+            # --- NEW: Connection Recovery ---
+            self._baud_optimized = False
+            _LOGGER.warning(
+                "Monoprice communication error (%s). Connection state reset; re-negotiating baud rate on next poll.",
+                err,
+            )
+            raise UpdateFailed(f"Error communicating with API: {err}")
         except Exception as err:
             raise UpdateFailed(f"Error communicating with API: {err}")

--- a/custom_components/monoprice_custom/coordinator.py
+++ b/custom_components/monoprice_custom/coordinator.py
@@ -1,0 +1,33 @@
+from datetime import timedelta
+import logging
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+_LOGGER = logging.getLogger(__name__)
+
+class MonopriceCoordinator(DataUpdateCoordinator):
+    """Class to manage fetching Monoprice data asynchronously."""
+
+    def __init__(self, hass, api):
+        """Initialize."""
+        self.api = api
+        super().__init__(
+            hass,
+            _LOGGER,
+            name="Monoprice 6-Zone",
+            update_interval=timedelta(seconds=5),
+        )
+
+    async def _async_update_data(self):
+        """Fetch data from the amp via executor job."""
+        try:
+            # Wrap synchronous status polling
+            zones = {}
+            for zone_id in range(11, 17): # Zones 1-6
+                zone_status = await self.hass.async_add_executor_job(
+                    self.api.zone_status, zone_id
+                )
+                if zone_status:
+                    zones[zone_id] = zone_status
+            return zones
+        except Exception as err:
+            raise UpdateFailed(f"Error communicating with API: {err}")

--- a/custom_components/monoprice_custom/coordinator.py
+++ b/custom_components/monoprice_custom/coordinator.py
@@ -20,14 +20,47 @@ class MonopriceCoordinator(DataUpdateCoordinator):
     async def _async_update_data(self):
         """Fetch data from the amp via executor job."""
         try:
-            # Wrap synchronous status polling
+            # Wake-up ping
+            try:
+                _LOGGER.debug("Sending wake-up ping to amplifier.")
+                await self.hass.async_add_executor_job(self.api.serial.write, b"\r\n")
+            except Exception as e:
+                _LOGGER.debug("Wake-up ping failed (expected if locked): %s", e)
+
             zones = {}
-            for zone_id in range(11, 17): # Zones 1-6
-                zone_status = await self.hass.async_add_executor_job(
-                    self.api.zone_status, zone_id
-                )
-                if zone_status:
-                    zones[zone_id] = zone_status
+            for i in range(1, 4):
+                for j in range(1, 7):
+                    zone_id = (i * 10) + j
+                    
+                    # Performance optimization: Only build log strings if debug is on
+                    if _LOGGER.isEnabledFor(logging.DEBUG):
+                        _LOGGER.debug("Requesting status for Zone %s", zone_id)
+                        
+                    try:
+                        zone_status = await self.hass.async_add_executor_job(
+                            self.api.zone_status, zone_id
+                        )
+                        
+                        if zone_status:
+                            if _LOGGER.isEnabledFor(logging.DEBUG):
+                                _LOGGER.debug(
+                                    "Zone %s Response: Power=%s, Volume=%s, Source=%s", 
+                                    zone_id, zone_status.power, zone_status.volume, zone_status.source
+                                )
+                            zones[zone_id] = zone_status
+                            
+                    except Exception as loop_err:
+                        if "Connection timed out" in str(loop_err):
+                            if _LOGGER.isEnabledFor(logging.DEBUG):
+                                _LOGGER.debug("Timeout requesting Zone %s (Unit %s may not exist)", zone_id, i)
+                            if i > 1:
+                                pass # Ignore timeouts for secondary units
+                            else:
+                                raise loop_err
+                        else:
+                            raise loop_err
+                            
             return zones
+            
         except Exception as err:
             raise UpdateFailed(f"Error communicating with API: {err}")

--- a/custom_components/monoprice_custom/diagnostics.py
+++ b/custom_components/monoprice_custom/diagnostics.py
@@ -1,0 +1,39 @@
+"""Diagnostics support for Monoprice 6-Zone Amplifier."""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.core import HomeAssistant
+
+from .__init__ import MonopriceConfigEntry
+
+TO_REDACT = {"unique_id"}
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: MonopriceConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = entry.runtime_data.coordinator
+    
+    zone_data = {}
+    if coordinator.data:
+        for zone_id, status in coordinator.data.items():
+            zone_data[f"zone_{zone_id}"] = {
+                "power": status.power,
+                "volume": status.volume,
+                "mute": status.mute,
+                "source": status.source,
+                "treble": status.treble,
+                "bass": status.bass,
+                "balance": status.balance,
+                "pa": getattr(status, "pa", False),
+                "keypad": getattr(status, "keypad", False),
+                "do_not_disturb": getattr(status, "do_not_disturb", False),
+            }
+            
+    return {
+        "entry": async_redact_data(entry.as_dict(), TO_REDACT),
+        "zone_states": zone_data,
+        "api_connected": coordinator.last_update_success,
+    }

--- a/custom_components/monoprice_custom/manifest.json
+++ b/custom_components/monoprice_custom/manifest.json
@@ -1,12 +1,12 @@
 {
   "domain": "monoprice",
-  "name": "Monoprice 6-Zone Amplifier Custom",
-  "codeowners": ["@etsinko", "@OnFreund", "@TheBradleySanders"],
+  "name": "Monoprice 6-Zone Amplifier",
+  "codeowners": ["@trooperthorn"],
   "config_flow": true,
-  "documentation": "https://github.com/thebradleysanders/Custom_Components_Monoprice",
+  "dependencies": [],
+  "documentation": "https://github.com/trooperthorn/ha_int_monoprice_6chan",
   "iot_class": "local_polling",
-  "issue_tracker": "https://github.com/thebradleysanders/Custom_Components_Monoprice/issues",
-  "loggers": ["pymonoprice"],
-  "requirements": ["pymonoprice==0.4"],
-  "version":"1.2.4"
+  "requirements": ["pymonoprice==0.3", "pyserial>=3.5"],
+  "version": "2026.08.12",
+  "diagnostics": true
 }

--- a/custom_components/monoprice_custom/manifest.json
+++ b/custom_components/monoprice_custom/manifest.json
@@ -6,7 +6,7 @@
   "dependencies": [],
   "documentation": "https://github.com/trooperthorn/ha_int_monoprice_6chan",
   "iot_class": "local_polling",
-  "requirements": ["pymonoprice==0.3", "pyserial>=3.5"],
-  "version": "2026.08.12",
+  "requirements": ["pymonoprice==0.5", "pyserial>=3.5"],
+  "version": "v2026.08.12.3",
   "diagnostics": true
 }

--- a/custom_components/monoprice_custom/manifest.json
+++ b/custom_components/monoprice_custom/manifest.json
@@ -1,15 +1,14 @@
 {
   "domain": "monoprice",
-  "name": "Monoprice 6-Zone Audio",
-  "version": "2026.08.12",
+  "name": "Monoprice 6-Zone Amplifier",
   "codeowners": ["@trooperthorn"],
   "config_flow": true,
-  "documentation": "https://github.com/trooperthorn/ha_int_elkm1",
-  "issue_tracker": "https://github.com/trooperthorn/ha_int_elkm1/issues",
+  "dependencies": [],
+  "documentation": "https://github.com/trooperthorn/ha_int_monoprice_6chan",
+  "issue_tracker": "https://github.com/trooperthorn/ha_int_monoprice_6chan/issues",
+  "iot_class": "local_polling",
   "loggers": ["custom_components.monoprice"],
   "requirements": ["pymonoprice==0.5", "pyserial>=3.5"],
-  "dependencies": [],
-  "iot_class": "local_push",
-  "quality_scale": "platinum",
+  "version": "2026.08.13",
   "diagnostics": true
 }

--- a/custom_components/monoprice_custom/manifest.json
+++ b/custom_components/monoprice_custom/manifest.json
@@ -6,6 +6,7 @@
   "config_flow": true,
   "documentation": "https://github.com/trooperthorn/ha_int_elkm1",
   "issue_tracker": "https://github.com/trooperthorn/ha_int_elkm1/issues",
+  "loggers": ["custom_components.monoprice"],
   "requirements": ["pymonoprice==0.5", "pyserial>=3.5"],
   "dependencies": [],
   "iot_class": "local_push",

--- a/custom_components/monoprice_custom/manifest.json
+++ b/custom_components/monoprice_custom/manifest.json
@@ -1,12 +1,14 @@
 {
   "domain": "monoprice",
-  "name": "Monoprice 6-Zone Amplifier",
+  "name": "Monoprice 6-Zone Audio",
+  "version": "2026.08.12",
   "codeowners": ["@trooperthorn"],
   "config_flow": true,
-  "dependencies": [],
-  "documentation": "https://github.com/trooperthorn/ha_int_monoprice_6chan",
-  "iot_class": "local_polling",
+  "documentation": "https://github.com/trooperthorn/ha_int_elkm1",
+  "issue_tracker": "https://github.com/trooperthorn/ha_int_elkm1/issues",
   "requirements": ["pymonoprice==0.5", "pyserial>=3.5"],
-  "version": "v2026.08.12.3",
+  "dependencies": [],
+  "iot_class": "local_push",
+  "quality_scale": "platinum",
   "diagnostics": true
 }

--- a/custom_components/monoprice_custom/media_player.py
+++ b/custom_components/monoprice_custom/media_player.py
@@ -1,312 +1,300 @@
-"""Support for interfacing with Monoprice 6 zone home audio controller."""
+"""Support for interfacing with Monoprice 6-Zone Home Audio Controller."""
+from __future__ import annotations
+
 import logging
+from typing import Any
 
-from serial import SerialException
+import voluptuous as vol
 
-from homeassistant import core
 from homeassistant.components.media_player import (
     MediaPlayerDeviceClass,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
     MediaPlayerState,
 )
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PORT
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, entity_platform, service
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import config_validation as cv, entity_platform
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-import voluptuous as vol
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
-    CONF_NAME,
-    CONF_SOURCES,
-    DOMAIN,
-    FIRST_RUN,
-    MONOPRICE_OBJECT,
-    SERVICE_RESTORE,
-    SERVICE_SNAPSHOT,
-    SERVICE_SET_BALANCE,
-    SERVICE_SET_BASS,
-    SERVICE_SET_TREBLE,
     ATTR_BALANCE,
     ATTR_BASS,
-    ATTR_TREBLE
+    ATTR_TREBLE,
+    CONF_SOURCES,
+    DOMAIN,
 )
-
-SET_BALANCE_SCHEMA = vol.Schema(
-    {
-        vol.Optional("entity_id", default=[]): vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(ATTR_BALANCE, default=0): vol.All(int, vol.Range(min=0, max=21))
-    }
-)
-
-SET_BASS_SCHEMA = vol.Schema(
-    {
-        vol.Optional("entity_id", default=[]): vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(ATTR_BASS, default=5): vol.All(int, vol.Range(min=0, max=15))
-    }
-)
-
-SET_TREBLE_SCHEMA = vol.Schema(
-    {
-        vol.Optional("entity_id", default=[]): vol.All(cv.ensure_list, [cv.string]),
-        vol.Optional(ATTR_TREBLE, default=5): vol.All(int, vol.Range(min=0, max=15))
-    }
-)
+from .__init__ import MonopriceConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
-MAX_VOLUME = 38
-PARALLEL_UPDATES = 1
+MAX_VOLUME = 38.0
+
+# Schemas for custom entity services
+SET_BALANCE_SCHEMA = {
+    vol.Required(ATTR_BALANCE): vol.All(cv.positive_int, vol.Range(min=0, max=20))
+}
+
+SET_BASS_SCHEMA = {
+    vol.Required(ATTR_BASS): vol.All(cv.positive_int, vol.Range(min=0, max=14))
+}
+
+SET_TREBLE_SCHEMA = {
+    vol.Required(ATTR_TREBLE): vol.All(cv.positive_int, vol.Range(min=0, max=14))
+}
 
 
-@core.callback
-def _get_sources_from_dict(data):
-    sources_config = data[CONF_SOURCES]
+@callback
+def _get_sources_from_dict(data: dict[str, Any]) -> tuple[dict[int, str], dict[str, int], list[str]]:
+    """Format configured source dictionaries."""
+    sources_config = data.get(CONF_SOURCES, {})
     source_id_name = {int(index): name for index, name in sources_config.items()}
     source_name_id = {v: k for k, v in source_id_name.items()}
     source_names = sorted(source_name_id.keys(), key=lambda v: source_name_id[v])
 
-    return [source_id_name, source_name_id, source_names]
-
-
-@core.callback
-def _get_sources(config_entry):
-    if CONF_SOURCES in config_entry.options:
-        data = config_entry.options
-    else:
-        data = config_entry.data
-    return _get_sources_from_dict(data)
+    return source_id_name, source_name_id, source_names
 
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    entry: MonopriceConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Monoprice 6-zone amplifier platform."""
-    port = config_entry.data[CONF_PORT]
+    monoprice_data = entry.runtime_data
+    coordinator = monoprice_data.coordinator
 
-    monoprice = hass.data[DOMAIN][config_entry.entry_id][MONOPRICE_OBJECT]
+    # Retrieve sources configuration
+    sources_data = entry.options if CONF_SOURCES in entry.options else entry.data
+    sources = _get_sources_from_dict(sources_data)
 
-    sources = _get_sources(config_entry)
-
+    # Support up to 3 stacked units: Unit 1 (11-16), Unit 2 (21-26), Unit 3 (31-36)
+    # Plus Master Zone controllers (10, 20, 30)
     entities = []
     for i in range(1, 4):
+        # Add Master zone for unit (10, 20, 30)
+        entities.append(MonopriceZone(coordinator, entry.entry_id, i * 10, sources))
+        # Add individual zones (11-16, 21-26, 31-36)
         for j in range(1, 7):
             zone_id = (i * 10) + j
-            _LOGGER.info("Adding zone %d for port %s", zone_id, port)
-            entities.append(
-                MonopriceZone(monoprice, sources, config_entry.entry_id, zone_id)
-            )
+            entities.append(MonopriceZone(coordinator, entry.entry_id, zone_id, sources))
 
-    # only call update before add if it's the first run so we can try to detect zones
-    first_run = hass.data[DOMAIN][config_entry.entry_id][FIRST_RUN]
-    async_add_entities(entities, first_run)
+    async_add_entities(entities)
 
+    # Register entity services for custom actions
     platform = entity_platform.async_get_current_platform()
-
-    def _call_service(entities, service_call):
-        for entity in entities:
-            if service_call.service == SERVICE_SNAPSHOT:
-                entity.snapshot()
-            elif service_call.service == SERVICE_RESTORE:
-                entity.restore()
-            elif service_call.service == SERVICE_SET_BALANCE:
-                entity.set_balance(service_call)
-            elif service_call.service == SERVICE_SET_BASS:
-                entity.set_bass(service_call)
-            elif service_call.service == SERVICE_SET_TREBLE:
-                entity.set_treble(service_call)
-
-    @service.verify_domain_control(DOMAIN)
-    async def async_service_handle(service_call: core.ServiceCall) -> None:
-        """Handle for services."""
-        entities = await platform.async_extract_from_service(service_call)
-
-        if not entities:
-            return
-
-        hass.async_add_executor_job(_call_service, entities, service_call)
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_SNAPSHOT,
-        async_service_handle,
-        schema=cv.make_entity_service_schema({}),
-    )
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_RESTORE,
-        async_service_handle,
-        schema=cv.make_entity_service_schema({}),
-    )
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_SET_BALANCE,
-        async_service_handle,
-        schema=SET_BALANCE_SCHEMA,
-    )
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_SET_BASS,
-        async_service_handle,
-        schema=SET_BASS_SCHEMA,
-    )
-
-    hass.services.async_register(
-        DOMAIN,
-        SERVICE_SET_TREBLE,
-        async_service_handle,
-        schema=SET_TREBLE_SCHEMA,
-    )
-
-class MonopriceZone(MediaPlayerEntity):
-    """Representation of a Monoprice amplifier zone."""
     
+    platform.async_register_entity_service("snapshot", {}, "async_snapshot")
+    platform.async_register_entity_service("restore", {}, "async_restore")
+    platform.async_register_entity_service("set_balance", SET_BALANCE_SCHEMA, "async_set_balance")
+    platform.async_register_entity_service("set_bass", SET_BASS_SCHEMA, "async_set_bass")
+    platform.async_register_entity_service("set_treble", SET_TREBLE_SCHEMA, "async_set_treble")
+
+
+class MonopriceZone(CoordinatorEntity, MediaPlayerEntity):
+    """Representation of a Monoprice amplifier zone."""
+
     _attr_device_class = MediaPlayerDeviceClass.RECEIVER
-    _attr_supported_features = (
-        MediaPlayerEntityFeature.VOLUME_MUTE
-        | MediaPlayerEntityFeature.VOLUME_SET
-        | MediaPlayerEntityFeature.VOLUME_STEP
-        | MediaPlayerEntityFeature.TURN_ON
-        | MediaPlayerEntityFeature.TURN_OFF
-        | MediaPlayerEntityFeature.SELECT_SOURCE
-        | MediaPlayerEntityFeature.SELECT_SOUND_MODE
-    )
     _attr_has_entity_name = True
     _attr_name = None
     _attr_sound_mode_list = ["Normal", "High Bass", "Medium Bass", "Low Bass"]
-    _attr_sound_mode = None
 
-    def __init__(self, monoprice, sources, namespace, zone_id):
+    def __init__(
+        self,
+        coordinator,
+        entry_id: str,
+        zone_id: int,
+        sources: tuple[dict[int, str], dict[str, int], list[str]],
+    ) -> None:
         """Initialize new zone."""
-        self._monoprice = monoprice
-        # dict source_id -> source name
-        self._source_id_name = sources[0]
-        # dict source name -> source_id
-        self._source_name_id = sources[1]
-        # ordered list of all source names
-        self._attr_source_list = sources[2]
-
+        super().__init__(coordinator)
         self._zone_id = zone_id
-        self._attr_unique_id = f"{namespace}_{self._zone_id}"
+        self._source_id_name, self._source_name_id, self._attr_source_list = sources
+
+        self._attr_unique_id = f"{entry_id}_{self._zone_id}"
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{namespace}_{self._zone_id}")},
+            identifiers={(DOMAIN, f"{entry_id}_{self._zone_id}")},
             manufacturer="Monoprice",
             model="6-Zone Amplifier",
-            name=f"Zone {self._zone_id}",
+            name=f"Zone {self._zone_id}" if self._zone_id not in [10, 20, 30] else f"Unit {self._zone_id // 10} Master",
         )
-        
+
+        self._attr_supported_features = (
+            MediaPlayerEntityFeature.VOLUME_MUTE
+            | MediaPlayerEntityFeature.VOLUME_SET
+            | MediaPlayerEntityFeature.VOLUME_STEP
+            | MediaPlayerEntityFeature.TURN_ON
+            | MediaPlayerEntityFeature.TURN_OFF
+            | MediaPlayerEntityFeature.SELECT_SOURCE
+            | MediaPlayerEntityFeature.SELECT_SOUND_MODE
+        )
+
         self._snapshot = None
-        self._update_success = True
-        
-
-    def update(self) -> None:
-        """Retrieve latest state."""
-        try:
-            state = self._monoprice.zone_status(self._zone_id)
-        except SerialException:
-            self._update_success = False
-            _LOGGER.warning("Could not update zone %d", self._zone_id)
-            return
-
-        if not state:
-            self._update_success = False
-            return
-
-        self._attr_state = MediaPlayerState.ON if state.power else MediaPlayerState.OFF
-        self._attr_volume_level = state.volume / MAX_VOLUME
-        self._attr_is_volume_muted = state.mute
-        idx = state.source
-        self._attr_source = self._source_id_name.get(idx)
+        self._sound_mode = "Normal"
 
     @property
     def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry."""
-        if(self._zone_id == 10 or self._zone_id == 20 or self._zone_id == 30):
+        """Return if entity is enabled by default when first added."""
+        # Disable master control zones (10, 20, 30) by default
+        if self._zone_id in (10, 20, 30):
             return False
-        return self._zone_id < 20 or self._update_success
+        # Enable Unit 1 by default; enable Units 2 & 3 only if hardware responds
+        return self._zone_id < 20 or (self.zone_data is not None)
 
     @property
-    def media_title(self):
-        """Return the current source as medial title."""
+    def zone_data(self) -> Any | None:
+        """Helper to get current zone status from coordinator."""
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.get(self._zone_id)
+
+    @property
+    def state(self) -> MediaPlayerState | None:
+        """Return the power state of the zone."""
+        if not self.zone_data:
+            return None
+        return MediaPlayerState.ON if self.zone_data.power else MediaPlayerState.OFF
+
+    @property
+    def volume_level(self) -> float | None:
+        """Return the volume level of the zone (0.0 to 1.0)."""
+        if not self.zone_data:
+            return None
+        return self.zone_data.volume / MAX_VOLUME
+
+    @property
+    def is_volume_muted(self) -> bool | None:
+        """Return boolean if volume is muted."""
+        if not self.zone_data:
+            return None
+        return self.zone_data.mute
+
+    @property
+    def source(self) -> str | None:
+        """Return the current input source."""
+        if not self.zone_data:
+            return None
+        return self._source_id_name.get(self.zone_data.source)
+
+    @property
+    def media_title(self) -> str | None:
+        """Return the current source as media title."""
         return self.source
 
-    def snapshot(self):
-        """Save zone's current state."""
-        self._snapshot = self._monoprice.zone_status(self._zone_id)
+    @property
+    def sound_mode(self) -> str | None:
+        """Return the current sound mode."""
+        return self._sound_mode
 
-    def restore(self):
-        """Restore saved state."""
-        if self._snapshot:
-            self._monoprice.restore_zone(self._snapshot)
-            self.schedule_update_ha_state(True)
-
-    def select_source(self, source: str) -> None:
-        """Set input source."""
-        if source not in self._source_name_id:
-            return
-        idx = self._source_name_id[source]
-        self._monoprice.set_source(self._zone_id, idx)
-
-    def turn_on(self) -> None:
+    async def async_turn_on(self) -> None:
         """Turn the media player on."""
-        self._monoprice.set_power(self._zone_id, True)
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.set_power, self._zone_id, True
+        )
+        await self.coordinator.async_request_refresh()
 
-    def turn_off(self) -> None:
+    async def async_turn_off(self) -> None:
         """Turn the media player off."""
-        self._monoprice.set_power(self._zone_id, False)
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.set_power, self._zone_id, False
+        )
+        await self.coordinator.async_request_refresh()
 
-    def mute_volume(self, mute: bool) -> None:
+    async def async_mute_volume(self, mute: bool) -> None:
         """Mute (true) or unmute (false) media player."""
-        self._monoprice.set_mute(self._zone_id, mute)
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.set_mute, self._zone_id, mute
+        )
+        await self.coordinator.async_request_refresh()
 
-    def set_volume_level(self, volume: float) -> None:
+    async def async_set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
-        self._monoprice.set_volume(self._zone_id, round(volume * MAX_VOLUME))
+        target_vol = round(volume * MAX_VOLUME)
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.set_volume, self._zone_id, target_vol
+        )
+        await self.coordinator.async_request_refresh()
 
-    def volume_up(self) -> None:
+    async def async_volume_up(self) -> None:
         """Volume up the media player."""
         if self.volume_level is None:
             return
-        volume = round(self.volume_level * MAX_VOLUME)
-        self._monoprice.set_volume(self._zone_id, min(volume + 1, MAX_VOLUME))
+        current_vol = round(self.volume_level * MAX_VOLUME)
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.set_volume, self._zone_id, min(current_vol + 1, int(MAX_VOLUME))
+        )
+        await self.coordinator.async_request_refresh()
 
-    def volume_down(self) -> None:
+    async def async_volume_down(self) -> None:
         """Volume down media player."""
         if self.volume_level is None:
             return
-        volume = round(self.volume_level * MAX_VOLUME)
-        self._monoprice.set_volume(self._zone_id, max(volume - 1, 0))
+        current_vol = round(self.volume_level * MAX_VOLUME)
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.set_volume, self._zone_id, max(current_vol - 1, 0)
+        )
+        await self.coordinator.async_request_refresh()
 
-    def set_balance(self, call) -> None:
-        """Set balance level."""
-        level = int(call.data.get(ATTR_BALANCE))
-        self._monoprice.set_balance(self._zone_id, level)
- 
-    def set_bass(self, call) -> None:
-        """Set bass level."""
-        level = int(call.data.get(ATTR_BASS))
-        self._monoprice.set_bass(self._zone_id, level)
+    async def async_select_source(self, source: str) -> None:
+        """Select input source."""
+        if source not in self._source_name_id:
+            return
+        idx = self._source_name_id[source]
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.set_source, self._zone_id, idx
+        )
+        await self.coordinator.async_request_refresh()
 
-    def set_treble(self, call) -> None:
-        """Set treble level."""
-        level = int(call.data.get(ATTR_TREBLE))
-        self._monoprice.set_treble(self._zone_id, level)
-
-    def select_sound_mode(self, sound_mode) -> None:
-        """Switch the sound mode of the entity."""
+    async def async_select_sound_mode(self, sound_mode: str) -> None:
+        """Switch the sound mode preset."""
         self._sound_mode = sound_mode
-        if(sound_mode == "Normal"):
-            self._monoprice.set_bass(self._zone_id, 7)
-        elif(sound_mode == "High Bass"):
-            self._monoprice.set_bass(self._zone_id, 12)
-        elif(sound_mode == "Medium Bass"):
-            self._monoprice.set_bass(self._zone_id, 10)
-        elif(sound_mode == "Low Bass"):
-            self._monoprice.set_bass(self._zone_id, 3)
+        bass_level = 7
+        if sound_mode == "High Bass":
+            bass_level = 12
+        elif sound_mode == "Medium Bass":
+            bass_level = 10
+        elif sound_mode == "Low Bass":
+            bass_level = 3
+
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.set_bass, self._zone_id, bass_level
+        )
+        await self.coordinator.async_request_refresh()
+
+    # --- Custom Entity Services ---
+
+    async def async_snapshot() -> None:
+        """Save zone's current state."""
+        self._snapshot = await self.hass.async_add_executor_job(
+            self.coordinator.api.zone_status, self._zone_id
+        )
+
+    async def async_restore() -> None:
+        """Restore saved state."""
+        if self._snapshot:
+            await self.hass.async_add_executor_job(
+                self.coordinator.api.restore_zone, self._snapshot
+            )
+            await self.coordinator.async_request_refresh()
+
+    async def async_set_balance(self, balance: int) -> None:
+        """Set balance level (0-20)."""
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.set_balance, self._zone_id, balance
+        )
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_bass(self, bass: int) -> None:
+        """Set bass level (0-14)."""
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.set_bass, self._zone_id, bass
+        )
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_treble(self, treble: int) -> None:
+        """Set treble level (0-14)."""
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.set_treble, self._zone_id, treble
+        )
+        await self.coordinator.async_request_refresh()

--- a/custom_components/monoprice_custom/media_player.py
+++ b/custom_components/monoprice_custom/media_player.py
@@ -18,73 +18,41 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    ATTR_BALANCE,
-    ATTR_BASS,
-    ATTR_TREBLE,
-    CONF_SOURCES,
-    DOMAIN,
-)
+from .const import ATTR_BALANCE, ATTR_BASS, ATTR_TREBLE, CONF_SOURCES, DOMAIN
 from .__init__ import MonopriceConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
 MAX_VOLUME = 38.0
 
-# Schemas for custom entity services
-SET_BALANCE_SCHEMA = {
-    vol.Required(ATTR_BALANCE): vol.All(cv.positive_int, vol.Range(min=0, max=20))
-}
-
-SET_BASS_SCHEMA = {
-    vol.Required(ATTR_BASS): vol.All(cv.positive_int, vol.Range(min=0, max=14))
-}
-
-SET_TREBLE_SCHEMA = {
-    vol.Required(ATTR_TREBLE): vol.All(cv.positive_int, vol.Range(min=0, max=14))
-}
+SET_BALANCE_SCHEMA = {vol.Required(ATTR_BALANCE): vol.All(cv.positive_int, vol.Range(min=0, max=20))}
+SET_BASS_SCHEMA = {vol.Required(ATTR_BASS): vol.All(cv.positive_int, vol.Range(min=0, max=14))}
+SET_TREBLE_SCHEMA = {vol.Required(ATTR_TREBLE): vol.All(cv.positive_int, vol.Range(min=0, max=14))}
 
 
 @callback
 def _get_sources_from_dict(data: dict[str, Any]) -> tuple[dict[int, str], dict[str, int], list[str]]:
-    """Format configured source dictionaries."""
     sources_config = data.get(CONF_SOURCES, {})
     source_id_name = {int(index): name for index, name in sources_config.items()}
     source_name_id = {v: k for k, v in source_id_name.items()}
     source_names = sorted(source_name_id.keys(), key=lambda v: source_name_id[v])
-
     return source_id_name, source_name_id, source_names
 
 
-async def async_setup_entry(
-    hass: HomeAssistant,
-    entry: MonopriceConfigEntry,
-    async_add_entities: AddEntitiesCallback,
-) -> None:
-    """Set up the Monoprice 6-zone amplifier platform."""
-    monoprice_data = entry.runtime_data
-    coordinator = monoprice_data.coordinator
-
-    # Retrieve sources configuration
+async def async_setup_entry(hass: HomeAssistant, entry: MonopriceConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+    coordinator = entry.runtime_data.coordinator
     sources_data = entry.options if CONF_SOURCES in entry.options else entry.data
     sources = _get_sources_from_dict(sources_data)
 
-    # Support up to 3 stacked units: Unit 1 (11-16), Unit 2 (21-26), Unit 3 (31-36)
-    # Plus Master Zone controllers (10, 20, 30)
     entities = []
     for i in range(1, 4):
-        # Add Master zone for unit (10, 20, 30)
         entities.append(MonopriceZone(coordinator, entry.entry_id, i * 10, sources))
-        # Add individual zones (11-16, 21-26, 31-36)
         for j in range(1, 7):
-            zone_id = (i * 10) + j
-            entities.append(MonopriceZone(coordinator, entry.entry_id, zone_id, sources))
+            entities.append(MonopriceZone(coordinator, entry.entry_id, (i * 10) + j, sources))
 
     async_add_entities(entities)
 
-    # Register entity services for custom actions
     platform = entity_platform.async_get_current_platform()
-    
     platform.async_register_entity_service("snapshot", {}, "async_snapshot")
     platform.async_register_entity_service("restore", {}, "async_restore")
     platform.async_register_entity_service("set_balance", SET_BALANCE_SCHEMA, "async_set_balance")
@@ -93,25 +61,15 @@ async def async_setup_entry(
 
 
 class MonopriceZone(CoordinatorEntity, MediaPlayerEntity):
-    """Representation of a Monoprice amplifier zone."""
-
     _attr_device_class = MediaPlayerDeviceClass.RECEIVER
     _attr_has_entity_name = True
     _attr_name = None
     _attr_sound_mode_list = ["Normal", "High Bass", "Medium Bass", "Low Bass"]
 
-    def __init__(
-        self,
-        coordinator,
-        entry_id: str,
-        zone_id: int,
-        sources: tuple[dict[int, str], dict[str, int], list[str]],
-    ) -> None:
-        """Initialize new zone."""
+    def __init__(self, coordinator, entry_id: str, zone_id: int, sources: tuple[dict[int, str], dict[str, int], list[str]]) -> None:
         super().__init__(coordinator)
         self._zone_id = zone_id
         self._source_id_name, self._source_name_id, self._attr_source_list = sources
-
         self._attr_unique_id = f"{entry_id}_{self._zone_id}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{entry_id}_{self._zone_id}")},
@@ -119,182 +77,103 @@ class MonopriceZone(CoordinatorEntity, MediaPlayerEntity):
             model="6-Zone Amplifier",
             name=f"Zone {self._zone_id}" if self._zone_id not in [10, 20, 30] else f"Unit {self._zone_id // 10} Master",
         )
-
         self._attr_supported_features = (
-            MediaPlayerEntityFeature.VOLUME_MUTE
-            | MediaPlayerEntityFeature.VOLUME_SET
-            | MediaPlayerEntityFeature.VOLUME_STEP
-            | MediaPlayerEntityFeature.TURN_ON
-            | MediaPlayerEntityFeature.TURN_OFF
-            | MediaPlayerEntityFeature.SELECT_SOURCE
-            | MediaPlayerEntityFeature.SELECT_SOUND_MODE
+            MediaPlayerEntityFeature.VOLUME_MUTE | MediaPlayerEntityFeature.VOLUME_SET |
+            MediaPlayerEntityFeature.VOLUME_STEP | MediaPlayerEntityFeature.TURN_ON |
+            MediaPlayerEntityFeature.TURN_OFF | MediaPlayerEntityFeature.SELECT_SOURCE |
+            MediaPlayerEntityFeature.SELECT_SOUND_MODE
         )
-
         self._snapshot = None
         self._sound_mode = "Normal"
 
     @property
     def entity_registry_enabled_default(self) -> bool:
-        """Return if entity is enabled by default when first added."""
-        # Disable master control zones (10, 20, 30) by default
         if self._zone_id in (10, 20, 30):
             return False
-        # Enable Unit 1 by default; enable Units 2 & 3 only if hardware responds
         return self._zone_id < 20 or (self.zone_data is not None)
 
     @property
     def zone_data(self) -> Any | None:
-        """Helper to get current zone status from coordinator."""
-        if self.coordinator.data is None:
-            return None
-        return self.coordinator.data.get(self._zone_id)
+        return self.coordinator.data.get(self._zone_id) if self.coordinator.data else None
 
     @property
     def state(self) -> MediaPlayerState | None:
-        """Return the power state of the zone."""
-        if not self.zone_data:
-            return None
+        if not self.zone_data: return None
         return MediaPlayerState.ON if self.zone_data.power else MediaPlayerState.OFF
 
     @property
     def volume_level(self) -> float | None:
-        """Return the volume level of the zone (0.0 to 1.0)."""
-        if not self.zone_data:
-            return None
-        return self.zone_data.volume / MAX_VOLUME
+        return (self.zone_data.volume / MAX_VOLUME) if self.zone_data else None
 
     @property
     def is_volume_muted(self) -> bool | None:
-        """Return boolean if volume is muted."""
-        if not self.zone_data:
-            return None
-        return self.zone_data.mute
+        return self.zone_data.mute if self.zone_data else None
 
     @property
     def source(self) -> str | None:
-        """Return the current input source."""
-        if not self.zone_data:
-            return None
-        return self._source_id_name.get(self.zone_data.source)
+        return self._source_id_name.get(self.zone_data.source) if self.zone_data else None
 
     @property
     def media_title(self) -> str | None:
-        """Return the current source as media title."""
         return self.source
 
     @property
     def sound_mode(self) -> str | None:
-        """Return the current sound mode."""
         return self._sound_mode
 
     async def async_turn_on(self) -> None:
-        """Turn the media player on."""
-        await self.hass.async_add_executor_job(
-            self.coordinator.api.set_power, self._zone_id, True
-        )
+        await self.hass.async_add_executor_job(self.coordinator.api.set_power, self._zone_id, True)
         await self.coordinator.async_request_refresh()
 
     async def async_turn_off(self) -> None:
-        """Turn the media player off."""
-        await self.hass.async_add_executor_job(
-            self.coordinator.api.set_power, self._zone_id, False
-        )
+        await self.hass.async_add_executor_job(self.coordinator.api.set_power, self._zone_id, False)
         await self.coordinator.async_request_refresh()
 
     async def async_mute_volume(self, mute: bool) -> None:
-        """Mute (true) or unmute (false) media player."""
-        await self.hass.async_add_executor_job(
-            self.coordinator.api.set_mute, self._zone_id, mute
-        )
+        await self.hass.async_add_executor_job(self.coordinator.api.set_mute, self._zone_id, mute)
         await self.coordinator.async_request_refresh()
 
     async def async_set_volume_level(self, volume: float) -> None:
-        """Set volume level, range 0..1."""
-        target_vol = round(volume * MAX_VOLUME)
-        await self.hass.async_add_executor_job(
-            self.coordinator.api.set_volume, self._zone_id, target_vol
-        )
+        await self.hass.async_add_executor_job(self.coordinator.api.set_volume, self._zone_id, round(volume * MAX_VOLUME))
         await self.coordinator.async_request_refresh()
 
     async def async_volume_up(self) -> None:
-        """Volume up the media player."""
-        if self.volume_level is None:
-            return
-        current_vol = round(self.volume_level * MAX_VOLUME)
-        await self.hass.async_add_executor_job(
-            self.coordinator.api.set_volume, self._zone_id, min(current_vol + 1, int(MAX_VOLUME))
-        )
-        await self.coordinator.async_request_refresh()
+        if self.volume_level is not None:
+            await self.hass.async_add_executor_job(self.coordinator.api.set_volume, self._zone_id, min(round(self.volume_level * MAX_VOLUME) + 1, int(MAX_VOLUME)))
+            await self.coordinator.async_request_refresh()
 
     async def async_volume_down(self) -> None:
-        """Volume down media player."""
-        if self.volume_level is None:
-            return
-        current_vol = round(self.volume_level * MAX_VOLUME)
-        await self.hass.async_add_executor_job(
-            self.coordinator.api.set_volume, self._zone_id, max(current_vol - 1, 0)
-        )
-        await self.coordinator.async_request_refresh()
+        if self.volume_level is not None:
+            await self.hass.async_add_executor_job(self.coordinator.api.set_volume, self._zone_id, max(round(self.volume_level * MAX_VOLUME) - 1, 0))
+            await self.coordinator.async_request_refresh()
 
     async def async_select_source(self, source: str) -> None:
-        """Select input source."""
-        if source not in self._source_name_id:
-            return
-        idx = self._source_name_id[source]
-        await self.hass.async_add_executor_job(
-            self.coordinator.api.set_source, self._zone_id, idx
-        )
-        await self.coordinator.async_request_refresh()
+        if source in self._source_name_id:
+            await self.hass.async_add_executor_job(self.coordinator.api.set_source, self._zone_id, self._source_name_id[source])
+            await self.coordinator.async_request_refresh()
 
     async def async_select_sound_mode(self, sound_mode: str) -> None:
-        """Switch the sound mode preset."""
         self._sound_mode = sound_mode
-        bass_level = 7
-        if sound_mode == "High Bass":
-            bass_level = 12
-        elif sound_mode == "Medium Bass":
-            bass_level = 10
-        elif sound_mode == "Low Bass":
-            bass_level = 3
-
-        await self.hass.async_add_executor_job(
-            self.coordinator.api.set_bass, self._zone_id, bass_level
-        )
+        bass_level = {"High Bass": 12, "Medium Bass": 10, "Low Bass": 3}.get(sound_mode, 7)
+        await self.hass.async_add_executor_job(self.coordinator.api.set_bass, self._zone_id, bass_level)
         await self.coordinator.async_request_refresh()
 
-    # --- Custom Entity Services ---
+    async def async_snapshot(self) -> None:
+        self._snapshot = await self.hass.async_add_executor_job(self.coordinator.api.zone_status, self._zone_id)
 
-    async def async_snapshot() -> None:
-        """Save zone's current state."""
-        self._snapshot = await self.hass.async_add_executor_job(
-            self.coordinator.api.zone_status, self._zone_id
-        )
-
-    async def async_restore() -> None:
-        """Restore saved state."""
+    async def async_restore(self) -> None:
         if self._snapshot:
-            await self.hass.async_add_executor_job(
-                self.coordinator.api.restore_zone, self._snapshot
-            )
+            await self.hass.async_add_executor_job(self.coordinator.api.restore_zone, self._snapshot)
             await self.coordinator.async_request_refresh()
 
     async def async_set_balance(self, balance: int) -> None:
-        """Set balance level (0-20)."""
-        await self.hass.async_add_executor_job(
-            self.coordinator.api.set_balance, self._zone_id, balance
-        )
+        await self.hass.async_add_executor_job(self.coordinator.api.set_balance, self._zone_id, balance)
         await self.coordinator.async_request_refresh()
 
     async def async_set_bass(self, bass: int) -> None:
-        """Set bass level (0-14)."""
-        await self.hass.async_add_executor_job(
-            self.coordinator.api.set_bass, self._zone_id, bass
-        )
+        await self.hass.async_add_executor_job(self.coordinator.api.set_bass, self._zone_id, bass)
         await self.coordinator.async_request_refresh()
 
     async def async_set_treble(self, treble: int) -> None:
-        """Set treble level (0-14)."""
-        await self.hass.async_add_executor_job(
-            self.coordinator.api.set_treble, self._zone_id, treble
-        )
+        await self.hass.async_add_executor_job(self.coordinator.api.set_treble, self._zone_id, treble)
         await self.coordinator.async_request_refresh()

--- a/custom_components/monoprice_custom/media_player.py
+++ b/custom_components/monoprice_custom/media_player.py
@@ -39,16 +39,24 @@ def _get_sources_from_dict(data: dict[str, Any]) -> tuple[dict[int, str], dict[s
     return source_id_name, source_name_id, source_names
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: MonopriceConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+async def async_setup_entry(
+    hass: HomeAssistant, 
+    entry: MonopriceConfigEntry, 
+    async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up the Monoprice media player platform."""
     coordinator = entry.runtime_data.coordinator
     sources_data = entry.options if CONF_SOURCES in entry.options else entry.data
     sources = _get_sources_from_dict(sources_data)
 
     entities = []
-    for i in range(1, 4):
-        entities.append(MonopriceZone(coordinator, entry.entry_id, i * 10, sources))
+    # Loop ONLY over detected units
+    for unit in coordinator.active_units:
+        # Add Master control zone for the unit (10, 20, 30)
+        entities.append(MonopriceZone(coordinator, entry.entry_id, unit * 10, sources))
+        # Add individual zones (11-16, 21-26, 31-36)
         for j in range(1, 7):
-            entities.append(MonopriceZone(coordinator, entry.entry_id, (i * 10) + j, sources))
+            entities.append(MonopriceZone(coordinator, entry.entry_id, (unit * 10) + j, sources))
 
     async_add_entities(entities)
 

--- a/custom_components/monoprice_custom/number.py
+++ b/custom_components/monoprice_custom/number.py
@@ -27,9 +27,10 @@ async def async_setup_entry(
     coordinator = entry.runtime_data.coordinator
 
     entities = []
-    for i in range(1, 4):
+    # Loop ONLY over detected units
+    for unit in coordinator.active_units:
         for j in range(1, 7):
-            zone_id = (i * 10) + j
+            zone_id = (unit * 10) + j
             for control_type in ("Balance", "Bass", "Treble"):
                 entities.append(
                     MonopriceZoneNumber(

--- a/custom_components/monoprice_custom/number.py
+++ b/custom_components/monoprice_custom/number.py
@@ -1,133 +1,133 @@
-"""Support for interfacing with Monoprice 6 zone home audio controller."""
-from code import interact
+"""Support for Monoprice 6-Zone Amplifier EQ controls via number entities."""
+from __future__ import annotations
+
 import logging
+from typing import Any
 
-from serial import SerialException
-
-from homeassistant import core
-try:
-    from homeassistant.components.number import (
-        NumberEntity as NumberEntity,
-    )
-except ImportError:
-    from homeassistant.components.number import NumberEntity
-
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PORT
+from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, entity_platform, service
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    DOMAIN,
-    FIRST_RUN,
-    MONOPRICE_OBJECT
-)
+from .const import DOMAIN
+from .__init__ import MonopriceConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
+
 PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    entry: MonopriceConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Monoprice 6-zone amplifier platform."""
-    port = config_entry.data[CONF_PORT]
-    monoprice = hass.data[DOMAIN][config_entry.entry_id][MONOPRICE_OBJECT]
+    """Set up Monoprice number entities from a config entry."""
+    coordinator = entry.runtime_data.coordinator
 
     entities = []
     for i in range(1, 4):
         for j in range(1, 7):
             zone_id = (i * 10) + j
-            _LOGGER.info("Adding number entities for zone %d for port %s", zone_id, port)
-            entities.append(MonopriceZone(monoprice, "Balance", config_entry.entry_id, zone_id))
-            entities.append(MonopriceZone(monoprice, "Bass", config_entry.entry_id, zone_id))
-            entities.append(MonopriceZone(monoprice, "Treble", config_entry.entry_id, zone_id))
+            for control_type in ("Balance", "Bass", "Treble"):
+                entities.append(
+                    MonopriceZoneNumber(
+                        coordinator,
+                        entry.entry_id,
+                        zone_id,
+                        control_type,
+                    )
+                )
 
-    # only call update before add if it's the first run so we can try to detect zones
-    first_run = hass.data[DOMAIN][config_entry.entry_id][FIRST_RUN]
-    async_add_entities(entities, first_run)
+    async_add_entities(entities)
 
-    platform = entity_platform.async_get_current_platform()
 
-    @service.verify_domain_control(DOMAIN)
-    async def async_service_handle(service_call: core.ServiceCall) -> None:
-        """Handle for services."""
-        entities = await platform.async_extract_from_service(service_call)
+class MonopriceZoneNumber(CoordinatorEntity, NumberEntity):
+    """Representation of a Monoprice zone number control."""
 
-        if not entities:
-            return
+    _attr_has_entity_name = True
+    _attr_mode = NumberMode.SLIDER
+    _attr_native_step = 1.0
 
-class MonopriceZone(NumberEntity):
-    """Representation of a Monoprice amplifier zone."""
-
-    def __init__(self, monoprice, control_type, namespace, zone_id):
-        """Initialize new zone controls."""
-        self._monoprice = monoprice
-        self._control_type = control_type
+    def __init__(
+        self,
+        coordinator,
+        entry_id: str,
+        zone_id: int,
+        control_type: str,
+    ) -> None:
+        """Initialize new zone number controls."""
+        super().__init__(coordinator)
         self._zone_id = zone_id
-        
-        self._attr_unique_id = f"{namespace}_{self._zone_id}_{self._control_type}"
-        self._attr_has_entity_name = True
+        self._control_type = control_type
+
+        self._attr_unique_id = f"{entry_id}_{self._zone_id}_{self._control_type}"
         self._attr_name = f"{control_type} level"
-        self._attr_native_step = 1
-        self._attr_native_value = None
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{namespace}_{self._zone_id}")},
+            identifiers={(DOMAIN, f"{entry_id}_{self._zone_id}")},
             manufacturer="Monoprice",
             model="6-Zone Amplifier",
-            name=f"Zone {self._zone_id}"
+            name=f"Zone {self._zone_id}",
         )
 
-        if(control_type == "Balance"):
+        if control_type == "Balance":
             self._attr_native_min_value = 0
             self._attr_native_max_value = 20
             self._attr_icon = "mdi:scale-balance"
-        elif(control_type == "Bass"):
+        elif control_type == "Bass":
             self._attr_native_min_value = -7
             self._attr_native_max_value = 14
             self._attr_icon = "mdi:speaker"
-        elif(control_type == "Treble"):
+        elif control_type == "Treble":
             self._attr_native_min_value = -7
             self._attr_native_max_value = 14
             self._attr_icon = "mdi:surround-sound"
-            
-        self._update_success = True
-        
-    def update(self):
-        """Retrieve latest value."""
-        try:
-            state = self._monoprice.zone_status(self._zone_id)
-        except SerialException:
-            self._update_success = False
-            _LOGGER.warning("Could not update zone %d", self._zone_id)
-            return
-
-        if not state:
-            self._update_success = False
-            return
-
-        if(self._control_type == "Balance"):
-            self._attr_native_value = state.balance
-        elif(self._control_type == "Bass"):
-            self._attr_native_value = state.bass
-        elif(self._control_type == "Treble"):
-            self._attr_native_value = state.treble
 
     @property
     def entity_registry_enabled_default(self) -> bool:
         """Return if the entity should be enabled when first added to the entity registry."""
-        if(self._zone_id == 10 or self._zone_id == 20 or self._zone_id == 30):
+        if self._zone_id in (10, 20, 30):
             return False
-        return self._zone_id < 20 or self._update_success
+        return self._zone_id < 20 or (
+            self.coordinator.data is not None and self._zone_id in self.coordinator.data
+        )
 
-    def set_native_value(self, value: float) -> None:
-        """Update the current value."""
-        if(self._control_type == "Balance"):
-            self._monoprice.set_balance(self._zone_id, int(value))
-        elif(self._control_type == "Bass"):
-            self._monoprice.set_bass(self._zone_id, int(value))
-        elif(self._control_type == "Treble"):
-            self._monoprice.set_treble(self._zone_id, int(value))
+    @property
+    def zone_data(self) -> Any | None:
+        """Helper to retrieve current zone state from coordinator."""
+        if not self.coordinator.data:
+            return None
+        return self.coordinator.data.get(self._zone_id)
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the current value."""
+        if not self.zone_data:
+            return None
+
+        if self._control_type == "Balance":
+            return self.zone_data.balance
+        if self._control_type == "Bass":
+            return self.zone_data.bass
+        if self._control_type == "Treble":
+            return self.zone_data.treble
+        return None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the current value asynchronously."""
+        target_val = int(value)
+        if self._control_type == "Balance":
+            await self.hass.async_add_executor_job(
+                self.coordinator.api.set_balance, self._zone_id, target_val
+            )
+        elif self._control_type == "Bass":
+            await self.hass.async_add_executor_job(
+                self.coordinator.api.set_bass, self._zone_id, target_val
+            )
+        elif self._control_type == "Treble":
+            await self.hass.async_add_executor_job(
+                self.coordinator.api.set_treble, self._zone_id, target_val
+            )
+
+        await self.coordinator.async_request_refresh()

--- a/custom_components/monoprice_custom/remote.py
+++ b/custom_components/monoprice_custom/remote.py
@@ -1,33 +1,42 @@
+"""Support for raw RS232 string execution."""
+from __future__ import annotations
+
 from homeassistant.components.remote import RemoteEntity
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .__init__ import MonopriceConfigEntry
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant, entry: MonopriceConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
     """Set up the Monoprice remote platform."""
-    coordinator = entry.runtime_data
+    coordinator = entry.runtime_data.coordinator
     async_add_entities([MonopriceRemote(coordinator, entry.entry_id)])
+
 
 class MonopriceRemote(CoordinatorEntity, RemoteEntity):
     """Representation of the Monoprice RS232 controller."""
 
-    def __init__(self, coordinator, entry_id):
+    _attr_has_entity_name = True
+    _attr_name = "RS232 Controller"
+
+    def __init__(self, coordinator, entry_id: str) -> None:
         super().__init__(coordinator)
-        self._attr_unique_id = f"{entry_id}_rs232_remote"
-        self._attr_name = "Monoprice RS232 Controller"
+        self._attr_unique_id = f"{entry_id}_rs232"
 
     @property
-    def is_on(self):
-        """Always true if the integration is loaded."""
+    def is_on(self) -> bool:
+        """Always true if the integration is running."""
         return True
 
-    async def async_send_command(self, command: list[str], **kwargs):
+    async def async_send_command(self, command: list[str], **kwargs) -> None:
         """Send raw RS232 commands to the device."""
         for cmd in command:
-            # Send raw serial write through the executor
+            # Ensure it ends with a carriage return as required by the manual
+            if not cmd.endswith("\r"):
+                cmd += "\r"
             await self.hass.async_add_executor_job(
-                self.coordinator.api.serial.write, 
-                f"{cmd}\r\n".encode('ascii')
+                self.coordinator.api.serial.write, cmd.encode("ascii")
             )

--- a/custom_components/monoprice_custom/remote.py
+++ b/custom_components/monoprice_custom/remote.py
@@ -1,0 +1,33 @@
+from homeassistant.components.remote import RemoteEntity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities):
+    """Set up the Monoprice remote platform."""
+    coordinator = entry.runtime_data
+    async_add_entities([MonopriceRemote(coordinator, entry.entry_id)])
+
+class MonopriceRemote(CoordinatorEntity, RemoteEntity):
+    """Representation of the Monoprice RS232 controller."""
+
+    def __init__(self, coordinator, entry_id):
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{entry_id}_rs232_remote"
+        self._attr_name = "Monoprice RS232 Controller"
+
+    @property
+    def is_on(self):
+        """Always true if the integration is loaded."""
+        return True
+
+    async def async_send_command(self, command: list[str], **kwargs):
+        """Send raw RS232 commands to the device."""
+        for cmd in command:
+            # Send raw serial write through the executor
+            await self.hass.async_add_executor_job(
+                self.coordinator.api.serial.write, 
+                f"{cmd}\r\n".encode('ascii')
+            )

--- a/custom_components/monoprice_custom/sensor.py
+++ b/custom_components/monoprice_custom/sensor.py
@@ -1,116 +1,112 @@
-"""Support for interfacing with Monoprice 6 zone home audio controller."""
-from code import interact
+"""Support for Monoprice 6-Zone Amplifier sensors."""
+from __future__ import annotations
+
 import logging
+from typing import Any
 
-from serial import SerialException
-
-from homeassistant import core
-try:
-    from homeassistant.components.sensor import (
-        SensorEntity as SensorEntity,
-    )
-except ImportError:
-    from homeassistant.components.sensor import SensorEntity
-
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PORT
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, entity_platform, service
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    DOMAIN,
-    FIRST_RUN,
-    MONOPRICE_OBJECT
-)
+from .const import DOMAIN
+from .__init__ import MonopriceConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
+
 PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    entry: MonopriceConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
-    """Set up the Monoprice 6-zone amplifier platform."""
-    port = config_entry.data[CONF_PORT]
-    monoprice = hass.data[DOMAIN][config_entry.entry_id][MONOPRICE_OBJECT]
+    """Set up Monoprice sensor entities from a config entry."""
+    coordinator = entry.runtime_data.coordinator
 
     entities = []
-    for i in range(1, 4):
+    # Loop ONLY over dynamically detected active units
+    for unit in coordinator.active_units:
         for j in range(1, 7):
-            zone_id = (i * 10) + j
-            _LOGGER.info("Adding sensor entities for zone %d for port %s", zone_id, port)
-            entities.append(MonopriceZone(monoprice, "Keypad", config_entry.entry_id, zone_id))
-            entities.append(MonopriceZone(monoprice, "Public Anouncement", config_entry.entry_id, zone_id))
-            entities.append(MonopriceZone(monoprice, "Do Not Disturb", config_entry.entry_id, zone_id))
+            zone_id = (unit * 10) + j
+            for sensor_type in ("Keypad", "Public Announcement", "Do Not Disturb"):
+                entities.append(
+                    MonopriceZoneSensor(
+                        coordinator,
+                        entry.entry_id,
+                        zone_id,
+                        sensor_type,
+                    )
+                )
 
-    # only call update before add if it's the first run so we can try to detect zones
-    first_run = hass.data[DOMAIN][config_entry.entry_id][FIRST_RUN]
-    async_add_entities(entities, first_run)
+    async_add_entities(entities)
 
-    platform = entity_platform.async_get_current_platform()
 
-    @service.verify_domain_control(DOMAIN)
-    async def async_service_handle(service_call: core.ServiceCall) -> None:
-        """Handle for services."""
-        entities = await platform.async_extract_from_service(service_call)
+class MonopriceZoneSensor(CoordinatorEntity, SensorEntity):
+    """Representation of a Monoprice zone status sensor."""
 
-        if not entities:
-            return
+    _attr_has_entity_name = True
 
-class MonopriceZone(SensorEntity):
-    """Representation of a Monoprice amplifier zone."""
-
-    def __init__(self, monoprice, sensor_type, namespace, zone_id):
-        """Initialize new zone sensors."""
-        self._monoprice = monoprice
-        self._sensor_type = sensor_type
+    def __init__(
+        self,
+        coordinator,
+        entry_id: str,
+        zone_id: int,
+        sensor_type: str,
+    ) -> None:
+        """Initialize new zone sensor."""
+        super().__init__(coordinator)
         self._zone_id = zone_id
-        self._attr_unique_id = f"{namespace}_{self._zone_id}_{self._sensor_type}"
-        self._attr_has_entity_name = True
-        self._attr_name = f"{sensor_type}"
-        self._attr_native_value = None
+        self._sensor_type = sensor_type
+
+        # Create clean unique ID slug
+        clean_type = sensor_type.lower().replace(" ", "_")
+        self._attr_unique_id = f"{entry_id}_{self._zone_id}_{clean_type}"
+        self._attr_name = sensor_type
+
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{namespace}_{self._zone_id}")},
+            identifiers={(DOMAIN, f"{entry_id}_{self._zone_id}")},
             manufacturer="Monoprice",
             model="6-Zone Amplifier",
-            name=f"Zone {self._zone_id}"
+            name=f"Zone {self._zone_id}",
         )
 
-        if(sensor_type == "Keypad"):
+        if sensor_type == "Keypad":
             self._attr_icon = "mdi:dialpad"
-        elif(sensor_type == "Public Anouncement"):
+        elif "Public" in sensor_type:
             self._attr_icon = "mdi:bullhorn"
-        elif(sensor_type == "Do Not Disturb"):
+        elif sensor_type == "Do Not Disturb":
             self._attr_icon = "mdi:weather-night"
-            
-        self._update_success = True
-
-    def update(self):
-        """Retrieve latest value."""
-        try:
-            state = self._monoprice.zone_status(self._zone_id)
-        except SerialException:
-            self._update_success = False
-            _LOGGER.warning("Could not update zone %d", self._zone_id)
-            return
-
-        if not state:
-            self._update_success = False
-            return
-
-        if(self._sensor_type == "Keypad"):
-            self._attr_native_value = '{}'.format('Connected' if state.keypad else 'Disconnected')
-        elif(self._sensor_type == "Public Anouncement"):
-            self._attr_native_value = '{}'.format('On' if state.pa else 'Off')
-        elif(self._sensor_type == "Do Not Disturb"):
-            self._attr_native_value = '{}'.format('On' if state.do_not_disturb else 'Off')
 
     @property
     def entity_registry_enabled_default(self) -> bool:
-        """Return if the entity should be enabled when first added to the entity registry."""
-        if(self._zone_id == 10 or self._zone_id == 20 or self._zone_id == 30):
+        """Return if entity is enabled by default when first added."""
+        if self._zone_id in (10, 20, 30):
             return False
-        return self._zone_id < 20 or self._update_success
+        return self._zone_id < 20 or (
+            self.coordinator.data is not None and self._zone_id in self.coordinator.data
+        )
+
+    @property
+    def zone_data(self) -> Any | None:
+        """Helper to retrieve current zone state from coordinator."""
+        if not self.coordinator.data:
+            return None
+        return self.coordinator.data.get(self._zone_id)
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the current state value."""
+        if not self.zone_data:
+            return None
+
+        if self._sensor_type == "Keypad":
+            return "Connected" if getattr(self.zone_data, "keypad", False) else "Disconnected"
+        if "Public" in self._sensor_type:
+            return "On" if getattr(self.zone_data, "pa", False) else "Off"
+        if self._sensor_type == "Do Not Disturb":
+            return "On" if getattr(self.zone_data, "do_not_disturb", False) else "Off"
+
+        return None

--- a/custom_components/monoprice_custom/switch.py
+++ b/custom_components/monoprice_custom/switch.py
@@ -23,10 +23,10 @@ async def async_setup_entry(
     coordinator = entry.runtime_data.coordinator
 
     entities = []
-    # Loop over units 1-3, zones 1-6
-    for i in range(1, 4):
+    # Loop ONLY over detected units
+    for unit in coordinator.active_units:
         for j in range(1, 7):
-            zone_id = (i * 10) + j
+            zone_id = (unit * 10) + j
             entities.append(MonopricePASwitch(coordinator, entry.entry_id, zone_id))
             entities.append(MonopriceDNDSwitch(coordinator, entry.entry_id, zone_id))
 

--- a/custom_components/monoprice_custom/switch.py
+++ b/custom_components/monoprice_custom/switch.py
@@ -1,0 +1,115 @@
+"""Support for Monoprice 6-Zone Amplifier switches."""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .__init__ import MonopriceConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MonopriceConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Monoprice switch entities."""
+    coordinator = entry.runtime_data.coordinator
+
+    entities = []
+    # Loop over units 1-3, zones 1-6
+    for i in range(1, 4):
+        for j in range(1, 7):
+            zone_id = (i * 10) + j
+            entities.append(MonopricePASwitch(coordinator, entry.entry_id, zone_id))
+            entities.append(MonopriceDNDSwitch(coordinator, entry.entry_id, zone_id))
+
+    async_add_entities(entities)
+
+
+class MonopricePASwitch(CoordinatorEntity, SwitchEntity):
+    """Representation of a Monoprice Public Address (PA) switch."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Public Address"
+
+    def __init__(self, coordinator, entry_id: str, zone_id: int) -> None:
+        """Initialize PA switch."""
+        super().__init__(coordinator)
+        self._zone_id = zone_id
+        self._attr_unique_id = f"{entry_id}_{zone_id}_pa"
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Only enable if zone exists or is unit 1."""
+        if self._zone_id in (10, 20, 30):
+            return False
+        return self._zone_id < 20 or (self.coordinator.data and self._zone_id in self.coordinator.data)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if PA is active."""
+        if not self.coordinator.data or self._zone_id not in self.coordinator.data:
+            return None
+        return getattr(self.coordinator.data[self._zone_id], "pa", False)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn PA on."""
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.set_pa, self._zone_id, True
+        )
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn PA off."""
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.set_pa, self._zone_id, False
+        )
+        await self.coordinator.async_request_refresh()
+
+
+class MonopriceDNDSwitch(CoordinatorEntity, SwitchEntity):
+    """Representation of a Monoprice Do Not Disturb (DND) switch."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Do Not Disturb"
+
+    def __init__(self, coordinator, entry_id: str, zone_id: int) -> None:
+        """Initialize DND switch."""
+        super().__init__(coordinator)
+        self._zone_id = zone_id
+        self._attr_unique_id = f"{entry_id}_{zone_id}_dnd"
+
+    @property
+    def entity_registry_enabled_default(self) -> bool:
+        """Only enable if zone exists or is unit 1."""
+        if self._zone_id in (10, 20, 30):
+            return False
+        return self._zone_id < 20 or (self.coordinator.data and self._zone_id in self.coordinator.data)
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if DND is active."""
+        if not self.coordinator.data or self._zone_id not in self.coordinator.data:
+            return None
+        return getattr(self.coordinator.data[self._zone_id], "do_not_disturb", False)
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn DND on."""
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.set_dnd, self._zone_id, True
+        )
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn DND off."""
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.set_dnd, self._zone_id, False
+        )
+        await self.coordinator.async_request_refresh()

--- a/custom_components/monoprice_custom/text.py
+++ b/custom_components/monoprice_custom/text.py
@@ -1,0 +1,55 @@
+"""Support for renaming Monoprice Keypad LCD screens."""
+from __future__ import annotations
+
+from homeassistant.components.text import TextEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .__init__ import MonopriceConfigEntry
+from .const import DOMAIN
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: MonopriceConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up Monoprice text entities."""
+    coordinator = entry.runtime_data.coordinator
+    
+    entities = [
+        MonopriceKeypadText(coordinator, entry.entry_id, i, f"Source {i} Display Name") 
+        for i in range(1, 7)
+    ]
+    
+    # The 'M' command sets the boot welcome message on the keypad
+    entities.append(MonopriceKeypadText(coordinator, entry.entry_id, "M", "Keypad Welcome Message"))
+
+    async_add_entities(entities)
+
+
+class MonopriceKeypadText(CoordinatorEntity, TextEntity):
+    """Representation of the physical Keypad LCD display strings."""
+    
+    _attr_has_entity_name = True
+    _attr_native_max = 8 # The hardware strictly limits this to 8 characters
+
+    def __init__(self, coordinator, entry_id: str, command_id: int | str, name: str) -> None:
+        super().__init__(coordinator)
+        self._command_id = command_id
+        self._attr_name = name
+        self._attr_unique_id = f"{entry_id}_text_{command_id}"
+        self._attr_native_value = "" # State is write-only in the hardware
+
+    async def async_set_value(self, value: str) -> None:
+        """Send the renaming string to the RS232 port."""
+        if len(value) > 8:
+            value = value[:8]
+            
+        # Pad with spaces if less than 8 characters
+        padded_value = value.ljust(8)
+        command = f"{self._command_id}<{padded_value}\r".encode("ascii")
+
+        await self.hass.async_add_executor_job(
+            self.coordinator.api.serial.write, command
+        )
+        self._attr_native_value = value
+        self.async_write_ha_state()

--- a/hacs.json
+++ b/hacs.json
@@ -1,10 +1,10 @@
 {
-  "name": "Monoprice 6-Zone Home Audio Controller",
+  "name": "RS232 - Monoprice 6-Zone Home Audio Controller",
   "domains": [
     "media_player",
     "sensor",
     "number"
   ],
   "iot_class": "local_push",
-  "homeassistant": "2021.12.0b0"
+  "homeassistant": "2026.5.0"
 }


### PR DESCRIPTION
- Removes Unused Zones

- Hardware Power Cycles Reset Baud Rate: According to the Monoprice manual, unplugging or power-cycling the amplifier automatically resets its hardware baud rate back to 9600 baud.

- Runtime Recovery: If your Home Assistant server remains running while the amplifier loses power or gets unplugged, your coordinator (running at 38,400 baud) will suddenly start throwing SerialTimeoutException.

- Self-Healing Integration: By placing the negotiation logic in coordinator.py and tracking connection state with a flag (e.g., self._baud_optimized), the coordinator can catch a serial timeout, reset self._baud_optimized = False, and automatically re-negotiate back from 9600 to 38,400 baud on the very next poll cycle—without requiring you to reload the integration or restart Home Assistant.****

- Recommended Target Speed: 38,400 or 57,600 Baud
While the manual supports up to 230,400 baud, 8-bit microcontrollers and USB-to-serial chips (like FTDI/CH340) can experience clock drift and bit drops at maximum speeds over longer cables. 38,400 or 57,600 baud provides a 4x–6x speedup over 9600, dropping single-zone query times from ~30ms down to ~5ms with rock-solid stability.